### PR TITLE
Implement mark channels read endpoints

### DIFF
--- a/Assets/Plugins/StreamChat/Core/API/ChannelApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/ChannelApi.cs
@@ -142,7 +142,12 @@ namespace StreamChat.Core.API
                 StopWatchingResponseDTO>($"/channels/{channelType}/{channelId}/stop-watching",
                 channelStopWatchingRequest);
 
-        public Task<MarkReadResponse> MarkReadAsync(MarkChannelsReadRequest markChannelsReadRequest) =>
+        public Task<MarkReadResponse> MarkReadAsync(string channelType, string channelId,
+            MarkReadRequest markReadRequest) =>
+            Post<MarkReadRequest, MarkReadRequestDTO, MarkReadResponse, MarkReadResponseDTO>(
+                $"/channels/{channelType}/{channelId}/read", markReadRequest);
+
+        public Task<MarkReadResponse> MarkManyReadAsync(MarkChannelsReadRequest markChannelsReadRequest) =>
             Post<MarkChannelsReadRequest, MarkChannelsReadRequestDTO, MarkReadResponse, MarkReadResponseDTO>(
                 $"/channels/read", markChannelsReadRequest);
     }

--- a/Assets/Plugins/StreamChat/Core/API/ChannelApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/ChannelApi.cs
@@ -141,5 +141,9 @@ namespace StreamChat.Core.API
             Post<ChannelStopWatchingRequest, ChannelStopWatchingRequestDTO, StopWatchingResponse,
                 StopWatchingResponseDTO>($"/channels/{channelType}/{channelId}/stop-watching",
                 channelStopWatchingRequest);
+
+        public Task<MarkReadResponse> MarkReadAsync(MarkChannelsReadRequest markChannelsReadRequest) =>
+            Post<MarkChannelsReadRequest, MarkChannelsReadRequestDTO, MarkReadResponse, MarkReadResponseDTO>(
+                $"/channels/read", markChannelsReadRequest);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/API/IChannelApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/IChannelApi.cs
@@ -33,7 +33,8 @@ namespace StreamChat.Core.API
         /// Create or return a channel with a given type and id
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/unity/creating_channels/?language=unity#1.-creating-a-channel-using-a-channel-id</remarks>
-        Task<ChannelState> GetOrCreateChannelAsync(string channelType, string channelId, ChannelGetOrCreateRequest getOrCreateRequest);
+        Task<ChannelState> GetOrCreateChannelAsync(string channelType, string channelId,
+            ChannelGetOrCreateRequest getOrCreateRequest);
 
         /// <summary>
         /// <para>Updates a channel.</para>
@@ -42,13 +43,15 @@ namespace StreamChat.Core.API
         /// the <see cref="UpdateChannelPartialAsync"/> method instead.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/unity/channel_update/?language=unity</remarks>
-        Task<UpdateChannelResponse> UpdateChannelAsync(string channelType, string channelId, UpdateChannelRequest updateChannelRequest);
+        Task<UpdateChannelResponse> UpdateChannelAsync(string channelType, string channelId,
+            UpdateChannelRequest updateChannelRequest);
 
         /// <summary>
         /// Can be used to set and unset specific fields when it is necessary to retain additional custom data fields on the object.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/unity/channel_update/?language=unity</remarks>
-        Task<UpdateChannelPartialResponse> UpdateChannelPartialAsync(string channelType, string channelId, UpdateChannelPartialRequest updateChannelPartialRequest);
+        Task<UpdateChannelPartialResponse> UpdateChannelPartialAsync(string channelType, string channelId,
+            UpdateChannelPartialRequest updateChannelPartialRequest);
 
         /// <summary>
         /// <para>Deletes multiple channels.</para>
@@ -68,7 +71,8 @@ namespace StreamChat.Core.API
         /// If you want to delete both channel and message data then use <see cref="DeleteAsync"/> method instead.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/unity/truncate_channel/?language=unity</remarks>
-        Task<TruncateChannelResponse> TruncateChannelAsync(string channelType, string channelId, TruncateChannelRequest truncateChannelRequest);
+        Task<TruncateChannelResponse> TruncateChannelAsync(string channelType, string channelId,
+            TruncateChannelRequest truncateChannelRequest);
 
         /// <summary>
         /// <para>Mutes a channel.</para>
@@ -91,14 +95,16 @@ namespace StreamChat.Core.API
         /// Use <see cref="HideChannelAsync"/> to hide a channel.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/unity/muting_channels/?language=unity</remarks>
-        Task<ShowChannelResponse> ShowChannelAsync(string channelType, string channelId, ShowChannelRequest showChannelRequest);
+        Task<ShowChannelResponse> ShowChannelAsync(string channelType, string channelId,
+            ShowChannelRequest showChannelRequest);
 
         /// <summary>
         /// <para>Removes a channel from query channel requests for that user until a new message is added.</para>
         /// Use <see cref="ShowChannelAsync"/> to cancel this operation.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/unity/muting_channels/?language=unity</remarks>
-        Task<HideChannelResponse> HideChannelAsync(string channelType, string channelId, HideChannelRequest hideChannelRequest);
+        Task<HideChannelResponse> HideChannelAsync(string channelType, string channelId,
+            HideChannelRequest hideChannelRequest);
 
         /// <summary>
         /// <para>Queries members of a channel.</para>
@@ -116,5 +122,12 @@ namespace StreamChat.Core.API
         /// <remarks>https://getstream.io/chat/docs/unity/watch_channel/?language=unity#stop-watching-a-channel</remarks>
         Task<StopWatchingResponse> StopWatchingChannelAsync(string channelType, string channelId,
             ChannelStopWatchingRequest channelStopWatchingRequest);
+
+        /// <summary>
+        /// Mark channels as read. Pass a map of CID to a message ID that is considered last read by client.
+        /// If message ID is empty, the whole channel will be considered as read
+        /// </summary>
+        /// <remarks>https://getstream.io/chat/docs/unity/unread_channel/?language=unity</remarks>
+        Task<MarkReadResponse> MarkReadAsync(MarkChannelsReadRequest markChannelsReadRequest);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/API/IChannelApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/IChannelApi.cs
@@ -124,10 +124,18 @@ namespace StreamChat.Core.API
             ChannelStopWatchingRequest channelStopWatchingRequest);
 
         /// <summary>
-        /// Mark channels as read. Pass a map of CID to a message ID that is considered last read by client.
+        /// Marks channel as read up to the specific message
+        /// If message ID is empty, the whole channel will be considered as read
+        /// </summary>
+        /// <returns></returns>
+        Task<MarkReadResponse> MarkReadAsync(string channelType, string channelId,
+            MarkReadRequest markReadRequest);
+
+        /// <summary>
+        /// Mark multiple channels as read. Pass a map of CID to a message ID that is considered last read by client.
         /// If message ID is empty, the whole channel will be considered as read
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/unity/unread_channel/?language=unity</remarks>
-        Task<MarkReadResponse> MarkReadAsync(MarkChannelsReadRequest markChannelsReadRequest);
+        Task<MarkReadResponse> MarkManyReadAsync(MarkChannelsReadRequest markChannelsReadRequest);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/DTO/Events/EventMessageNewDTO.cs
+++ b/Assets/Plugins/StreamChat/Core/DTO/Events/EventMessageNewDTO.cs
@@ -46,6 +46,15 @@ namespace StreamChat.Core.DTO.Events
         [Newtonsoft.Json.JsonProperty("watcher_count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? WatcherCount { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("total_unread_count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? TotalUnreadCount { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("unread_channels", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? UnreadChannels { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("unread_count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? UnreadCount { get; set; }
+
         private System.Collections.Generic.Dictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
 
         [Newtonsoft.Json.JsonExtensionData]

--- a/Assets/Plugins/StreamChat/Core/DTO/Events/EventNotificationMessageNewDTO.cs
+++ b/Assets/Plugins/StreamChat/Core/DTO/Events/EventNotificationMessageNewDTO.cs
@@ -40,6 +40,15 @@ namespace StreamChat.Core.DTO.Events
         [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Type { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("total_unread_count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? TotalUnreadCount { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("unread_channels", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? UnreadChannels { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("unread_count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? UnreadCount { get; set; }
+
         private System.Collections.Generic.Dictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
 
         [Newtonsoft.Json.JsonExtensionData]

--- a/Assets/Plugins/StreamChat/Core/DTO/Models/ReadDTO.cs
+++ b/Assets/Plugins/StreamChat/Core/DTO/Models/ReadDTO.cs
@@ -20,7 +20,7 @@ namespace StreamChat.Core.DTO.Models
         public System.DateTimeOffset? LastRead { get; set; }
 
         [Newtonsoft.Json.JsonProperty("unread_messages", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public double? UnreadMessages { get; set; }
+        public int? UnreadMessages { get; set; }
 
         [Newtonsoft.Json.JsonProperty("user", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public UserObjectDTO User { get; set; }

--- a/Assets/Plugins/StreamChat/Core/DTO/Requests/MarkChannelsReadRequestDTO.cs
+++ b/Assets/Plugins/StreamChat/Core/DTO/Requests/MarkChannelsReadRequestDTO.cs
@@ -22,18 +22,6 @@ namespace StreamChat.Core.DTO.Requests
         [Newtonsoft.Json.JsonProperty("read_by_channel", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.Dictionary<string, string> ReadByChannel { get; set; }
 
-        /// <summary>
-        /// **Server-side only**. User object which server acts upon
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("user", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public UserObjectRequestDTO User { get; set; }
-
-        /// <summary>
-        /// **Server-side only**. User ID which server acts upon
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("user_id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string UserId { get; set; }
-
         private System.Collections.Generic.Dictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
 
         [Newtonsoft.Json.JsonExtensionData]

--- a/Assets/Plugins/StreamChat/Core/DTO/Requests/MarkReadRequestDTO.cs
+++ b/Assets/Plugins/StreamChat/Core/DTO/Requests/MarkReadRequestDTO.cs
@@ -21,28 +21,6 @@ namespace StreamChat.Core.DTO.Requests
         /// </summary>
         [Newtonsoft.Json.JsonProperty("message_id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string MessageId { get; set; }
-
-        /// <summary>
-        /// **Server-side only**. User object which server acts upon
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("user", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public UserObjectRequestDTO User { get; set; }
-
-        /// <summary>
-        /// **Server-side only**. User ID which server acts upon
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("user_id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string UserId { get; set; }
-
-        private System.Collections.Generic.Dictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
-
-        [Newtonsoft.Json.JsonExtensionData]
-        public System.Collections.Generic.Dictionary<string, object> AdditionalProperties
-        {
-            get { return _additionalProperties; }
-            set { _additionalProperties = value; }
-        }
-
     }
 
 }

--- a/Assets/Plugins/StreamChat/Core/DTO/Responses/ChannelMessagesDTO.cs
+++ b/Assets/Plugins/StreamChat/Core/DTO/Responses/ChannelMessagesDTO.cs
@@ -1,0 +1,15 @@
+﻿using StreamChat.Core.DTO.Models;
+
+namespace StreamChat.Core.DTO.Responses
+{
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.5.0 (NJsonSchema v10.6.6.0 (Newtonsoft.Json v9.0.0.0))")]
+    internal partial class ChannelMessagesDTO
+    {
+        [Newtonsoft.Json.JsonProperty("channel", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public ChannelResponseDTO Channel { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("messages", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.List<MessageDTO> Messages { get; set; }
+
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/DTO/Responses/ChannelMessagesDTO.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/DTO/Responses/ChannelMessagesDTO.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 73a33202ff8f4d99a8d4f9dbbf68526e
+timeCreated: 1660570967

--- a/Assets/Plugins/StreamChat/Core/Events/EventMessageRead.cs
+++ b/Assets/Plugins/StreamChat/Core/Events/EventMessageRead.cs
@@ -1,0 +1,42 @@
+﻿using StreamChat.Core.DTO.Events;
+using StreamChat.Core.DTO.Models;
+using StreamChat.Core.Helpers;
+using StreamChat.Core.Models;
+
+namespace StreamChat.Core.Events
+{
+    /// <summary>
+    /// Trigger: when a channel is marked as read
+    /// Recipients: clients watching the channel
+    /// </summary>
+    public partial class EventMessageRead : EventBase, ILoadableFrom<EventMessageReadDTO, EventMessageRead>
+    {
+        public string ChannelId { get; set; }
+
+        public string ChannelType { get; set; }
+
+        public string Cid { get; set; }
+
+        public System.DateTimeOffset? CreatedAt { get; set; }
+
+        public string Team { get; set; }
+
+        public string Type { get; set; }
+
+        public User User { get; set; }
+
+        EventMessageRead ILoadableFrom<EventMessageReadDTO, EventMessageRead>.LoadFromDto(EventMessageReadDTO dto)
+        {
+            ChannelId = dto.ChannelId;
+            ChannelType = dto.ChannelType;
+            Cid = dto.Cid;
+            CreatedAt = dto.CreatedAt;
+            Team = dto.Team;
+            Type = dto.Type;
+            User = User.TryLoadFromDto<UserObjectDTO, User>(dto.User);
+            AdditionalProperties = dto.AdditionalProperties;
+
+            return this;
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Events/EventMessageRead.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Events/EventMessageRead.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 67d2c95458e54555a37466b6fdc0486d
+timeCreated: 1660568254

--- a/Assets/Plugins/StreamChat/Core/Events/EventNotificationMarkRead.cs
+++ b/Assets/Plugins/StreamChat/Core/Events/EventNotificationMarkRead.cs
@@ -1,0 +1,55 @@
+﻿using StreamChat.Core.DTO.Events;
+using StreamChat.Core.DTO.Models;
+using StreamChat.Core.Events;
+using StreamChat.Core.Helpers;
+using StreamChat.Core.Models;
+
+namespace StreamChat.Core.Events
+{
+    /// <summary>
+    /// Trigger: when the total count of unread messages (across all channels the user is a member) changes
+    /// Recipients: clients from the user removed that are not watching the channel
+    /// </summary>
+    public partial class EventNotificationMarkRead : EventBase, ILoadableFrom<EventNotificationMarkReadDTO, EventNotificationMarkRead>
+    {
+        public Channel Channel { get; set; }
+
+        public string ChannelId { get; set; }
+
+        public string ChannelType { get; set; }
+
+        public string Cid { get; set; }
+
+        public System.DateTimeOffset? CreatedAt { get; set; }
+
+        public string Team { get; set; }
+
+        public int? TotalUnreadCount { get; set; }
+
+        public string Type { get; set; }
+
+        public int? UnreadChannels { get; set; }
+
+        public int? UnreadCount { get; set; }
+
+        public User User { get; set; }
+
+        EventNotificationMarkRead ILoadableFrom<EventNotificationMarkReadDTO, EventNotificationMarkRead>.LoadFromDto(EventNotificationMarkReadDTO dto)
+        {
+            Channel = Channel.TryLoadFromDto(dto.Channel);
+            ChannelId = dto.ChannelId;
+            ChannelType = dto.ChannelType;
+            Cid = dto.Cid;
+            CreatedAt = dto.CreatedAt;
+            Team = dto.Team;
+            TotalUnreadCount = dto.TotalUnreadCount;
+            Type = dto.Type;
+            UnreadChannels = dto.UnreadChannels;
+            UnreadCount = dto.UnreadCount;
+            User = User.TryLoadFromDto<UserObjectDTO, User>(dto.User);
+            AdditionalProperties = dto.AdditionalProperties;
+
+            return this;
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Events/EventNotificationMarkRead.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Events/EventNotificationMarkRead.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e848c17376b448a1a0aaecf9b3d30d5c
+timeCreated: 1660571340

--- a/Assets/Plugins/StreamChat/Core/Events/EventNotificationMessageNew.cs
+++ b/Assets/Plugins/StreamChat/Core/Events/EventNotificationMessageNew.cs
@@ -1,12 +1,15 @@
 ﻿using StreamChat.Core.DTO.Events;
 using StreamChat.Core.DTO.Models;
+using StreamChat.Core.Events;
 using StreamChat.Core.Helpers;
 using StreamChat.Core.Models;
 
 namespace StreamChat.Core.Events
 {
-    public class EventMessageNew : EventBase, ILoadableFrom<EventMessageNewDTO, EventMessageNew>
+    public partial class EventNotificationMessageNew : EventBase, ILoadableFrom<EventNotificationMessageNewDTO, EventNotificationMessageNew>
     {
+        public Channel Channel { get; set; }
+
         public string ChannelId { get; set; }
 
         public string ChannelType { get; set; }
@@ -19,13 +22,7 @@ namespace StreamChat.Core.Events
 
         public string Team { get; set; }
 
-        public System.Collections.Generic.List<User> ThreadParticipants { get; set; }
-
         public string Type { get; set; }
-
-        public User User { get; set; }
-
-        public int? WatcherCount { get; set; }
 
         public int? TotalUnreadCount { get; set; }
 
@@ -33,18 +30,16 @@ namespace StreamChat.Core.Events
 
         public int? UnreadCount { get; set; }
 
-        EventMessageNew ILoadableFrom<EventMessageNewDTO, EventMessageNew>.LoadFromDto(EventMessageNewDTO dto)
+        EventNotificationMessageNew ILoadableFrom<EventNotificationMessageNewDTO, EventNotificationMessageNew>.LoadFromDto(EventNotificationMessageNewDTO dto)
         {
+            Channel = Channel.TryLoadFromDto(dto.Channel);
             ChannelId = dto.ChannelId;
             ChannelType = dto.ChannelType;
             Cid = dto.Cid;
             CreatedAt = dto.CreatedAt;
             Message = Message.TryLoadFromDto(dto.Message);
             Team = dto.Team;
-            ThreadParticipants = ThreadParticipants.TryLoadFromDtoCollection(dto.ThreadParticipants);
             Type = dto.Type;
-            User = User.TryLoadFromDto<UserObjectDTO, User>(dto.User);
-            WatcherCount = dto.WatcherCount;
             TotalUnreadCount = dto.TotalUnreadCount;
             UnreadChannels = dto.UnreadChannels;
             UnreadCount = dto.UnreadCount;

--- a/Assets/Plugins/StreamChat/Core/Events/EventNotificationMessageNew.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Events/EventNotificationMessageNew.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5bed0733a3854143929e67fca823609a
+timeCreated: 1660665243

--- a/Assets/Plugins/StreamChat/Core/IStreamRealtimeEventsProvider.cs
+++ b/Assets/Plugins/StreamChat/Core/IStreamRealtimeEventsProvider.cs
@@ -15,7 +15,7 @@ namespace StreamChat.Core
         event Action<string> EventReceived;
 
         /// <summary>
-        /// Event raised when a new message has been received to a watched channel.
+        /// Event raised when a new message has been sent to a watched channel.
         ///
         /// Use <see cref="EventMessageNew.Cid"/> to know which channel it belongs to.
         /// </summary>
@@ -77,5 +77,14 @@ namespace StreamChat.Core
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/unity/event_object/?language=unity</remarks>
         event Action<EventNotificationMarkRead> NotificationMarkRead;
+
+        /// <summary>
+        /// Notification Event raised when a new message is sent to channel the user is member of.
+        ///
+        /// Notifications are sent to all channel members regardless of whether they're actively watching this channel.
+        /// Use <see cref="EventNotificationMessageNew.Cid"/> & <see cref="EventNotificationMessageNew.Message"/> to know which channel & message it belongs to.
+        /// </summary>
+        /// <remarks>https://getstream.io/chat/docs/unity/event_object/?language=unity</remarks>
+        event Action<EventNotificationMessageNew> NotificationMessageReceived;
     }
 }

--- a/Assets/Plugins/StreamChat/Core/IStreamRealtimeEventsProvider.cs
+++ b/Assets/Plugins/StreamChat/Core/IStreamRealtimeEventsProvider.cs
@@ -39,6 +39,14 @@ namespace StreamChat.Core
         event Action<EventMessageDeleted> MessageDeleted;
 
         /// <summary>
+        /// Event raised when a when a watched channel is marked as read.
+        ///
+        /// Use <see cref="EventMessageRead.Cid"/> to know which channel it belongs to.
+        /// </summary>
+        /// <remarks>https://getstream.io/chat/docs/unity/event_object/?language=unity</remarks>
+        event Action<EventMessageRead> MessageRead;
+
+        /// <summary>
         /// Event raised when a reaction has been added to the message of a watched channel.
         ///
         /// Use <see cref="EventReactionNew.Cid"/> & <see cref="EventReactionNew.Message"/> to know which channel & message it belongs to.
@@ -61,5 +69,13 @@ namespace StreamChat.Core
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/unity/event_object/?language=unity</remarks>
         event Action<EventReactionDeleted> ReactionDeleted;
+
+        /// <summary>
+        /// Notification Event raised when the total count of unread messages (across all channels the user is a member) changes.
+        ///
+        /// Use <see cref="EventNotificationMarkRead.Cid"/> & <see cref="EventNotificationMarkRead.Channel"/> to know which channel it belongs to.
+        /// </summary>
+        /// <remarks>https://getstream.io/chat/docs/unity/event_object/?language=unity</remarks>
+        event Action<EventNotificationMarkRead> NotificationMarkRead;
     }
 }

--- a/Assets/Plugins/StreamChat/Core/Models/Read.cs
+++ b/Assets/Plugins/StreamChat/Core/Models/Read.cs
@@ -7,7 +7,7 @@ namespace StreamChat.Core.Models
     {
         public System.DateTimeOffset? LastRead { get; set; }
 
-        public double? UnreadMessages { get; set; }
+        public int? UnreadMessages { get; set; }
 
         public User User { get; set; }
 

--- a/Assets/Plugins/StreamChat/Core/Requests/MarkChannelsReadRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/Requests/MarkChannelsReadRequest.cs
@@ -1,0 +1,20 @@
+﻿using StreamChat.Core.DTO.Requests;
+using StreamChat.Core.Requests;
+
+namespace StreamChat.Core.Requests
+{
+    public partial class MarkChannelsReadRequest : RequestObjectBase, ISavableTo<MarkChannelsReadRequestDTO>
+    {
+        /// <summary>
+        /// Map which binds a CID to a message ID that is considered last read by client. If message ID is empty, the whole channel will be considered as read
+        /// </summary>
+        public System.Collections.Generic.Dictionary<string, string> ReadByChannel { get; set; }
+
+        MarkChannelsReadRequestDTO ISavableTo<MarkChannelsReadRequestDTO>.SaveToDto() =>
+            new MarkChannelsReadRequestDTO
+            {
+                ReadByChannel = ReadByChannel,
+                AdditionalProperties = AdditionalProperties
+            };
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Requests/MarkChannelsReadRequest.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Requests/MarkChannelsReadRequest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1ad240f148ad44f5900df91f4d0db104
+timeCreated: 1660566498

--- a/Assets/Plugins/StreamChat/Core/Requests/MarkReadRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/Requests/MarkReadRequest.cs
@@ -1,0 +1,18 @@
+﻿using StreamChat.Core.DTO.Requests;
+
+namespace StreamChat.Core.Requests
+{
+    public partial class MarkReadRequest : RequestObjectBase, ISavableTo<MarkReadRequestDTO>
+    {
+        /// <summary>
+        /// ID of the message that is considered last read by client
+        /// </summary>
+        public string MessageId { get; set; }
+
+        MarkReadRequestDTO ISavableTo<MarkReadRequestDTO>.SaveToDto() =>
+            new MarkReadRequestDTO
+            {
+                MessageId = MessageId,
+            };
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Requests/MarkReadRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/Requests/MarkReadRequest.cs
@@ -5,7 +5,7 @@ namespace StreamChat.Core.Requests
     public partial class MarkReadRequest : RequestObjectBase, ISavableTo<MarkReadRequestDTO>
     {
         /// <summary>
-        /// ID of the message that is considered last read by client
+        /// ID of the message that is considered last read by client. If empty the whole channel will be considered as read
         /// </summary>
         public string MessageId { get; set; }
 

--- a/Assets/Plugins/StreamChat/Core/Requests/MarkReadRequest.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Requests/MarkReadRequest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: be64be3b8b4b4b4fa25f0a4b8694e023
+timeCreated: 1660563579

--- a/Assets/Plugins/StreamChat/Core/Responses/ChannelMessages.cs
+++ b/Assets/Plugins/StreamChat/Core/Responses/ChannelMessages.cs
@@ -1,0 +1,22 @@
+﻿using StreamChat.Core.DTO.Responses;
+using StreamChat.Core.Helpers;
+using StreamChat.Core.Models;
+using StreamChat.Core.Responses;
+
+namespace StreamChat.Core.Responses
+{
+    public partial class ChannelMessages : ResponseObjectBase, ILoadableFrom<ChannelMessagesDTO, ChannelMessages>
+    {
+        public Channel Channel { get; set; }
+
+        public System.Collections.Generic.List<Message> Messages { get; set; }
+
+        ChannelMessages ILoadableFrom<ChannelMessagesDTO, ChannelMessages>.LoadFromDto(ChannelMessagesDTO dto)
+        {
+            Channel = Channel.TryLoadFromDto(dto.Channel);
+            Messages = Messages.TryLoadFromDtoCollection(dto.Messages);
+
+            return this;
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Responses/ChannelMessages.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Responses/ChannelMessages.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: de4100fce6534763a5a554080599513f
+timeCreated: 1660571234

--- a/Assets/Plugins/StreamChat/Core/Responses/Event.cs
+++ b/Assets/Plugins/StreamChat/Core/Responses/Event.cs
@@ -1,0 +1,108 @@
+﻿using StreamChat.Core.DTO.Events;
+using StreamChat.Core.DTO.Models;
+using StreamChat.Core.Helpers;
+using StreamChat.Core.Models;
+using StreamChat.Core.Responses;
+
+namespace StreamChat.Core.Responses
+{
+    public partial class Event : ResponseObjectBase, ILoadableFrom<EventDTO, Event>
+    {
+        /// <summary>
+        /// Only applicable to `message.flagged` event.
+        /// </summary>
+        public bool? Automoderation { get; set; }
+
+        /// <summary>
+        /// Only applicable to `message.flagged` event.
+        /// </summary>
+        public ModerationResponse AutomoderationScores { get; set; }
+
+        public Channel Channel { get; set; }
+
+        public string ChannelId { get; set; }
+
+        public string ChannelType { get; set; }
+
+        /// <summary>
+        /// Channel CID (&lt;type&gt;:&lt;id&gt;)
+        /// </summary>
+        public string Cid { get; set; }
+
+        /// <summary>
+        /// Only applicable to `health.check` event
+        /// </summary>
+        public string ConnectionId { get; set; }
+
+        /// <summary>
+        /// Date/time of creation
+        /// </summary>
+        public System.DateTimeOffset? CreatedAt { get; set; }
+
+        /// <summary>
+        /// User who issued moderation action. Only applicable to moderation-related events
+        /// </summary>
+        public User CreatedBy { get; set; }
+
+        public OwnUser Me { get; set; }
+
+        public ChannelMember Member { get; set; }
+
+        public Message Message { get; set; }
+
+        /// <summary>
+        /// ID of thread. Used in typing events
+        /// </summary>
+        public string ParentId { get; set; }
+
+        public Reaction Reaction { get; set; }
+
+        /// <summary>
+        /// Ban reason. Only applicable to `user.banned` event
+        /// </summary>
+        public string Reason { get; set; }
+
+        public string Team { get; set; }
+
+        /// <summary>
+        /// Event type. To use custom event types see Custom Events documentation
+        /// </summary>
+        public string Type { get; set; }
+
+        public User User { get; set; }
+
+        public string UserId { get; set; }
+
+        /// <summary>
+        /// Number of watchers who received this event
+        /// </summary>
+        public int? WatcherCount { get; set; }
+
+        Event ILoadableFrom<EventDTO, Event>.LoadFromDto(EventDTO dto)
+        {
+            Automoderation = dto.Automoderation;
+            AutomoderationScores = AutomoderationScores.TryLoadFromDto(dto.AutomoderationScores);
+            Channel = Channel.TryLoadFromDto(dto.Channel);
+            ChannelId = dto.ChannelId;
+            ChannelType = dto.ChannelType;
+            Cid = dto.Cid;
+            ConnectionId = dto.ConnectionId;
+            CreatedAt = dto.CreatedAt;
+            CreatedBy = CreatedBy.TryLoadFromDto<UserObjectDTO, User>(dto.CreatedBy);
+            Me = Me.TryLoadFromDto<OwnUserDTO, OwnUser>(dto.Me);
+            Member = Member.TryLoadFromDto(dto.Member);
+            Message = Message.TryLoadFromDto(dto.Message);
+            ParentId = dto.ParentId;
+            Reaction = Reaction.TryLoadFromDto(dto.Reaction);
+            Reason = dto.Reason;
+            Team = dto.Team;
+            Type = dto.Type;
+            User = User.TryLoadFromDto<UserObjectDTO, User>(dto.User);
+            UserId = dto.UserId;
+            WatcherCount = dto.WatcherCount;
+            AdditionalProperties = dto.AdditionalProperties;
+
+            return this;
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Responses/Event.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Responses/Event.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9bb60a8da3f14d3d866bcabf888b1c3d
+timeCreated: 1660566004

--- a/Assets/Plugins/StreamChat/Core/Responses/MarkReadResponse.cs
+++ b/Assets/Plugins/StreamChat/Core/Responses/MarkReadResponse.cs
@@ -1,0 +1,28 @@
+﻿using StreamChat.Core.DTO.Responses;
+using StreamChat.Core.Helpers;
+using StreamChat.Core.Responses;
+
+namespace StreamChat.Core.Responses
+{
+    public partial class MarkReadResponse : ResponseObjectBase, ILoadableFrom<MarkReadResponseDTO, MarkReadResponse>
+    {
+        /// <summary>
+        /// Duration of the request in human-readable format
+        /// </summary>
+        public string Duration { get; set; }
+
+        /// <summary>
+        /// Mark read event
+        /// </summary>
+        public Event Event { get; set; }
+
+        MarkReadResponse ILoadableFrom<MarkReadResponseDTO, MarkReadResponse>.LoadFromDto(MarkReadResponseDTO dto)
+        {
+            Duration = dto.Duration;
+            Event = Event.TryLoadFromDto(dto.Event);
+            AdditionalProperties = dto.AdditionalProperties;
+                
+            return this;
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Responses/MarkReadResponse.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Responses/MarkReadResponse.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2271ca7f5f2f4ffe95a63c146225c595
+timeCreated: 1660566004

--- a/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
@@ -15,7 +15,6 @@ using StreamChat.Core.Auth;
 using StreamChat.Core.Events;
 using StreamChat.Core.Exceptions;
 using StreamChat.Core.Models;
-using StreamChat.Core;
 using StreamChat.Core.Web;
 using StreamChat.Libs;
 using StreamChat.Libs.Auth;
@@ -49,6 +48,7 @@ namespace StreamChat.Core
         public event Action<EventReactionDeleted> ReactionDeleted;
 
         public event Action<EventNotificationMarkRead> NotificationMarkRead;
+        public event Action<EventNotificationMessageNew> NotificationMessageReceived;
 
         public IChannelApi ChannelApi { get; }
         public IMessageApi MessageApi { get; }
@@ -269,6 +269,8 @@ namespace StreamChat.Core
                 e => MessageRead?.Invoke(e));
             RegisterEventType<EventNotificationMarkReadDTO, EventNotificationMarkRead>(EventType.NotificationMarkRead,
                 e => NotificationMarkRead?.Invoke(e));
+            RegisterEventType<EventNotificationMessageNewDTO, EventNotificationMessageNew>(EventType.NotificationMessageNew,
+                e => NotificationMessageReceived?.Invoke(e));
         }
 
         private void Reconnect()
@@ -355,14 +357,12 @@ namespace StreamChat.Core
             }
 
             var timeSinceLastHealthCheckSent = _timeService.Time - _lastHealthCheckSendTime;
-
             if (timeSinceLastHealthCheckSent > HealthCheckSendInterval)
             {
                 PingHealthCheck();
             }
 
             var timeSinceLastHealthCheck = _timeService.Time - _lastHealthCheckReceivedTime;
-
             if (timeSinceLastHealthCheck > HealthCheckMaxWaitingTime)
             {
                 _logs.Warning($"Health check was not received since: {timeSinceLastHealthCheck}, attempt to reconnect");

--- a/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
@@ -42,9 +42,13 @@ namespace StreamChat.Core
         public event Action<EventMessageUpdated> MessageUpdated;
         public event Action<EventMessageDeleted> MessageDeleted;
 
+        public event Action<EventMessageRead> MessageRead;
+
         public event Action<EventReactionNew> ReactionReceived;
         public event Action<EventReactionUpdated> ReactionUpdated;
         public event Action<EventReactionDeleted> ReactionDeleted;
+
+        public event Action<EventNotificationMarkRead> NotificationMarkRead;
 
         public IChannelApi ChannelApi { get; }
         public IMessageApi MessageApi { get; }
@@ -260,6 +264,11 @@ namespace StreamChat.Core
                 e => ReactionUpdated?.Invoke(e));
             RegisterEventType<EventReactionDeletedDTO, EventReactionDeleted>(EventType.ReactionDeleted,
                 e => ReactionDeleted?.Invoke(e));
+
+            RegisterEventType<EventMessageReadDTO, EventMessageRead>(EventType.MessageRead,
+                e => MessageRead?.Invoke(e));
+            RegisterEventType<EventNotificationMarkReadDTO, EventNotificationMarkRead>(EventType.NotificationMarkRead,
+                e => NotificationMarkRead?.Invoke(e));
         }
 
         private void Reconnect()

--- a/Assets/Plugins/StreamChat/EditorTools/CommandLineParser.cs
+++ b/Assets/Plugins/StreamChat/EditorTools/CommandLineParser.cs
@@ -56,7 +56,7 @@ namespace StreamChat.EditorTools
             var testAuthDataSet = ParseTestAuthDataSetArg(args);
 
             return (new BuildSettings(buildTargetGroup, apiCompatibilityLevel, scriptingImplementation, targetPath),
-                testAuthDataSet.GetRandomAdminData());
+                testAuthDataSet.GetAdminData());
         }
 
         public TestAuthDataSet ParseTestAuthDataSetArg(IDictionary<string, string> args)

--- a/Assets/Plugins/StreamChat/EditorTools/TestAuthDataSet.cs
+++ b/Assets/Plugins/StreamChat/EditorTools/TestAuthDataSet.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using StreamChat.Libs.Auth;
 using Random = UnityEngine.Random;
@@ -19,5 +20,21 @@ namespace StreamChat.EditorTools
         }
 
         public AuthCredentials GetRandomAdminData() => TestAdminData[Random.Range(0, TestAdminData.Length)];
+
+        public AuthCredentials GetOtherThan(AuthCredentials authCredentials)
+        {
+            for (int i = 0; i < TestAdminData.Length; i++)
+            {
+                if (TestAdminData[i].UserId == authCredentials.UserId)
+                {
+                    continue;
+                }
+
+                return TestAdminData[i];
+            }
+
+            throw new InvalidOperationException(
+                $"Failed to find {nameof(AuthCredentials)} other than for user with id: " + authCredentials.UserId);
+        }
     }
 }

--- a/Assets/Plugins/StreamChat/EditorTools/TestAuthDataSet.cs
+++ b/Assets/Plugins/StreamChat/EditorTools/TestAuthDataSet.cs
@@ -12,14 +12,20 @@ namespace StreamChat.EditorTools
         public AuthCredentials TestUserData { get; set; }
         public AuthCredentials TestGuestData { get; set; }
 
-        public TestAuthDataSet(IEnumerable<AuthCredentials> testAdminData, AuthCredentials testUserData, AuthCredentials testGuestData)
+        public TestAuthDataSet(IEnumerable<AuthCredentials> testAdminData, AuthCredentials testUserData,
+            AuthCredentials testGuestData)
         {
             TestAdminData = testAdminData.ToArray();
             TestUserData = testUserData;
             TestGuestData = testGuestData;
         }
 
-        public AuthCredentials GetRandomAdminData() => TestAdminData[Random.Range(0, TestAdminData.Length)];
+        public AuthCredentials GetAdminData(string forcedAdminId = null)
+        {
+            return forcedAdminId != null
+                ? TestAdminData.First(_ => _.UserId == forcedAdminId)
+                : TestAdminData[Random.Range(0, TestAdminData.Length)];
+        }
 
         public AuthCredentials GetOtherThan(AuthCredentials authCredentials)
         {

--- a/Assets/Plugins/StreamChat/SampleProject/Scripts/ChatState.cs
+++ b/Assets/Plugins/StreamChat/SampleProject/Scripts/ChatState.cs
@@ -8,6 +8,7 @@ using StreamChat.Core.Exceptions;
 using StreamChat.Core.Models;
 using StreamChat.Core.Requests;
 using StreamChat.Libs.Logs;
+using StreamChat.SampleProject.Utils;
 using StreamChat.SampleProject.Views;
 using UnityEngine;
 
@@ -54,9 +55,12 @@ namespace StreamChat.SampleProject
             Client.MessageReceived += OnMessageReceived;
             Client.MessageDeleted += OnMessageDeleted;
             Client.MessageUpdated += OnMessageUpdated;
+            Client.MessageRead += OnMessageRead;
             Client.ReactionReceived += OnReactionReceived;
             Client.ReactionUpdated += OnReactionUpdated;
             Client.ReactionDeleted += OnReactionDeleted;
+
+            Client.NotificationMarkRead += OnNotificationMarkRead;
         }
 
         public void Dispose()
@@ -65,9 +69,12 @@ namespace StreamChat.SampleProject
             Client.MessageReceived -= OnMessageReceived;
             Client.MessageDeleted -= OnMessageDeleted;
             Client.MessageUpdated -= OnMessageUpdated;
+            Client.MessageRead -= OnMessageRead;
             Client.ReactionReceived -= OnReactionReceived;
             Client.ReactionUpdated -= OnReactionUpdated;
             Client.ReactionDeleted -= OnReactionDeleted;
+
+            Client.NotificationMarkRead -= OnNotificationMarkRead;
 
             Client.Dispose();
         }
@@ -97,6 +104,21 @@ namespace StreamChat.SampleProject
         public void OpenChannel(ChannelState channel) => ActiveChannel = channel;
 
         public void EditMessage(Message message) => MessageEditRequested?.Invoke(message);
+
+        public void MarkMessageAsLastRead(Message message)
+        {
+            var channel = _channels.FirstOrDefault(_ => _.Channel.Cid == message.Cid);
+            if (channel == null)
+            {
+                Debug.LogError("Failed to find channel with CID: " + message.Cid);
+                return;
+            }
+
+            Client.ChannelApi.MarkReadAsync(channel.Channel.Type, channel.Channel.Id, new MarkReadRequest()
+            {
+                MessageId = message.Id
+            }).LogStreamExceptionIfFailed();
+        }
 
         public async Task UpdateChannelsAsync()
         {
@@ -173,15 +195,16 @@ namespace StreamChat.SampleProject
 
             try
             {
-                var channelState = await Client.ChannelApi.GetOrCreateChannelAsync(ActiveChannel.Channel.Type, ActiveChannel.Channel.Id, new ChannelGetOrCreateRequest
-                {
-                    State = true,
-                    Messages = new MessagePaginationParamsRequest
+                var channelState = await Client.ChannelApi.GetOrCreateChannelAsync(ActiveChannel.Channel.Type,
+                    ActiveChannel.Channel.Id, new ChannelGetOrCreateRequest
                     {
-                        IdLt = firstMessage.Id,
-                        Limit = 50,
-                    },
-                });
+                        State = true,
+                        Messages = new MessagePaginationParamsRequest
+                        {
+                            IdLt = firstMessage.Id,
+                            Limit = 50,
+                        },
+                    });
 
                 if (channelState.Messages == null || channelState.Messages.Count == 0)
                 {
@@ -270,6 +293,13 @@ namespace StreamChat.SampleProject
 
         private void OnReactionUpdated(EventReactionUpdated eventReactionUpdated) =>
             UpdateChannelMessage(eventReactionUpdated.Message);
+
+        private void OnNotificationMarkRead(EventNotificationMarkRead eventNotificationMarkRead) =>
+            Debug.Log($"Notified mark read for channel: {eventNotificationMarkRead.Cid}, " +
+                      $"TotalUnreadCount: {eventNotificationMarkRead.TotalUnreadCount}, UnreadChannels: {eventNotificationMarkRead.UnreadChannels}");
+
+        private void OnMessageRead(EventMessageRead eventMessageRead) =>
+            Debug.Log("Message read received for channel: " + eventMessageRead.Cid);
 
         private ChannelState GetChannel(string id) => _channels.First(_ => _.Channel.Id == id);
 

--- a/Assets/Plugins/StreamChat/SampleProject/Scripts/IChatState.cs
+++ b/Assets/Plugins/StreamChat/SampleProject/Scripts/IChatState.cs
@@ -36,5 +36,7 @@ namespace StreamChat.SampleProject
         Task UpdateChannelsAsync();
 
         Task LoadPreviousMessagesAsync();
+
+        void MarkMessageAsLastRead(Message message);
     }
 }

--- a/Assets/Plugins/StreamChat/SampleProject/Scripts/Views/ViewFactory.cs
+++ b/Assets/Plugins/StreamChat/SampleProject/Scripts/Views/ViewFactory.cs
@@ -70,6 +70,8 @@ namespace StreamChat.SampleProject.Views
                 }));
             }
 
+            options.Add(new MenuOptionEntry("Mark as read", () => state.MarkMessageAsLastRead(message)));
+
             options.Add(new MenuOptionEntry("Delete",
                 () => client.MessageApi.DeleteMessageAsync(message.Id, hard: false).LogStreamExceptionIfFailed()));
 

--- a/Assets/Plugins/StreamChat/Tests/Integration/BaseIntegrationTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/Integration/BaseIntegrationTests.cs
@@ -46,6 +46,7 @@ namespace StreamChat.Tests.Integration
                 guestAuthCredentials = testAuthDataSet.TestGuestData;
                 userAuthCredentials = testAuthDataSet.TestUserData;
                 adminAuthCredentials = testAuthDataSet.GetRandomAdminData();
+                OtherUserId = testAuthDataSet.GetOtherThan(adminAuthCredentials).UserId;
             }
             else if (File.Exists(TestAuthDataFilePath))
             {
@@ -62,6 +63,7 @@ namespace StreamChat.Tests.Integration
                 guestAuthCredentials = testAuthDataSet.TestGuestData;
                 userAuthCredentials = testAuthDataSet.TestUserData;
                 adminAuthCredentials = testAuthDataSet.GetRandomAdminData();
+                OtherUserId = testAuthDataSet.GetOtherThan(adminAuthCredentials).UserId;
             }
             else
             {
@@ -83,6 +85,8 @@ namespace StreamChat.Tests.Integration
                     apiKey: ApiKey,
                     userId: TestAdminId,
                     userToken: "");
+
+                OtherUserId = "";
             }
 
             Client = StreamChatClient.CreateDefaultClient(adminAuthCredentials);
@@ -105,6 +109,11 @@ namespace StreamChat.Tests.Integration
         protected const string TestGuestId = "integration-tests-role-guest";
 
         protected IStreamChatClient Client { get; private set; }
+
+        /// <summary>
+        /// Id of other user than currently logged one
+        /// </summary>
+        protected string OtherUserId { get; private set; }
 
         /// <summary>
         ///  Create temp channel with random id that will be removed in [TearDown]

--- a/Assets/Plugins/StreamChat/Tests/Integration/ChannelApiIntegrationTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/Integration/ChannelApiIntegrationTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using StreamChat.Core.Exceptions;
 using StreamChat.Core.Models;
 using StreamChat.Core.Requests;
+using StreamChat.Core.Responses;
 using UnityEngine.TestTools;
 
 namespace StreamChat.Tests.Integration
@@ -48,9 +49,9 @@ namespace StreamChat.Tests.Integration
                 {
                     AdditionalProperties = new Dictionary<string, object>
                     {
-                        {"MyNumber", 3},
-                        {"MyString", "Hey Joe!"},
-                        {"MyIntArray", new int[]{5, 8, 9}}
+                        { "MyNumber", 3 },
+                        { "MyString", "Hey Joe!" },
+                        { "MyIntArray", new int[] { 5, 8, 9 } }
                     }
                 },
             };
@@ -192,7 +193,8 @@ namespace StreamChat.Tests.Integration
             const string channelType = "messaging";
 
             ChannelState channelState = null;
-            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(), state => channelState = state);
+            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(),
+                state => channelState = state);
             var channelId = channelState.Channel.Id;
 
             var updateRequestBody = new UpdateChannelRequest
@@ -313,7 +315,8 @@ namespace StreamChat.Tests.Integration
             var channelType = "messaging";
 
             ChannelState channelState = null;
-            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(), state => channelState = state);
+            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(),
+                state => channelState = state);
             var channelId = channelState.Channel.Id;
 
             var deleteChannelTask = Client.ChannelApi.DeleteChannelAsync(channelType, channelId);
@@ -331,7 +334,8 @@ namespace StreamChat.Tests.Integration
             var channelType = "messaging";
             var channelId = "new-channel-id-1";
 
-            var createChannelTask = Client.ChannelApi.GetOrCreateChannelAsync(channelType, channelId, new ChannelGetOrCreateRequest());
+            var createChannelTask =
+                Client.ChannelApi.GetOrCreateChannelAsync(channelType, channelId, new ChannelGetOrCreateRequest());
 
             yield return createChannelTask.RunAsIEnumerator(response =>
             {
@@ -361,9 +365,12 @@ namespace StreamChat.Tests.Integration
 
             var channelsCIdsToDelete = new List<string>();
 
-            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(), state => channelsCIdsToDelete.Add(state.Channel.Cid));
-            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(), state => channelsCIdsToDelete.Add(state.Channel.Cid));
-            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(), state => channelsCIdsToDelete.Add(state.Channel.Cid));
+            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(),
+                state => channelsCIdsToDelete.Add(state.Channel.Cid));
+            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(),
+                state => channelsCIdsToDelete.Add(state.Channel.Cid));
+            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(),
+                state => channelsCIdsToDelete.Add(state.Channel.Cid));
 
             Assert.AreEqual(channelsCIdsToDelete.Count, 3);
 
@@ -390,26 +397,27 @@ namespace StreamChat.Tests.Integration
             var channelType = "messaging";
 
             ChannelState channelState = null;
-            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(), state => channelState = state);
+            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(),
+                state => channelState = state);
             var channelId = channelState.Channel.Id;
 
-            var updateChannelPartialTask = Client.ChannelApi.UpdateChannelPartialAsync(channelType, channelId, new UpdateChannelPartialRequest
-            {
-                Set = new Dictionary<string, object>
+            var updateChannelPartialTask = Client.ChannelApi.UpdateChannelPartialAsync(channelType, channelId,
+                new UpdateChannelPartialRequest
                 {
-                    {"owned_dogs", 2},
-                    {"owned_hamsters", 4},
-                    {"breakfast", new string[]
+                    Set = new Dictionary<string, object>
                     {
-                        "oatmeal", "juice"
-                    }}
-                }
-            });
+                        { "owned_dogs", 2 },
+                        { "owned_hamsters", 4 },
+                        {
+                            "breakfast", new string[]
+                            {
+                                "oatmeal", "juice"
+                            }
+                        }
+                    }
+                });
 
-            yield return updateChannelPartialTask.RunAsIEnumerator(response =>
-            {
-
-            });
+            yield return updateChannelPartialTask.RunAsIEnumerator(response => { });
 
             var getOrCreateTask2 =
                 Client.ChannelApi.GetOrCreateChannelAsync(channelType, channelId, new ChannelGetOrCreateRequest());
@@ -424,26 +432,26 @@ namespace StreamChat.Tests.Integration
                 // Assert.That(response.Channel.AdditionalProperties["breakfast"], Contains.Item("juice"));
             });
 
-            var updateChannelPartialTask2 = Client.ChannelApi.UpdateChannelPartialAsync(channelType, channelId, new UpdateChannelPartialRequest
-            {
-                Set = new Dictionary<string, object>
+            var updateChannelPartialTask2 = Client.ChannelApi.UpdateChannelPartialAsync(channelType, channelId,
+                new UpdateChannelPartialRequest
                 {
-                    {"owned_dogs", 5},
-                    {"breakfast", new string[]
+                    Set = new Dictionary<string, object>
                     {
-                        "donuts"
-                    }}
-                },
-                Unset = new List<string>
-                {
-                    "owned_hamsters"
-                }
-            });
+                        { "owned_dogs", 5 },
+                        {
+                            "breakfast", new string[]
+                            {
+                                "donuts"
+                            }
+                        }
+                    },
+                    Unset = new List<string>
+                    {
+                        "owned_hamsters"
+                    }
+                });
 
-            yield return updateChannelPartialTask2.RunAsIEnumerator(response =>
-            {
-
-            });
+            yield return updateChannelPartialTask2.RunAsIEnumerator(response => { });
 
             var getOrCreateTask3 =
                 Client.ChannelApi.GetOrCreateChannelAsync(channelType, channelId, new ChannelGetOrCreateRequest());
@@ -456,6 +464,183 @@ namespace StreamChat.Tests.Integration
                 //Todo: add support - this array is Newtonsoft.Json.Linq.JArray
                 //Assert.That(response.Channel.AdditionalProperties["breakfast"], Contains.Item("donuts"));
                 //Assert.That(response.Channel.AdditionalProperties["breakfast"], Has.Exactly(1).Count);
+            });
+        }
+
+        /// <summary>
+        /// 1. Create 3 channels with 3 messages
+        /// 2. Mark first, second and third message as read for each channel respectively
+        /// 3. query channels and validate 2, 1, 0 unread messages respectively
+        /// </summary>
+        [UnityTest]
+        public IEnumerator Mark_read()
+        {
+            IEnumerator SendTestMessages(ChannelState channelState,
+                Action<(int Index, MessageResponse MessageResponse)> onMessageSent)
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    var sendMessageTask = Client.MessageApi.SendNewMessageAsync(channelState.Channel.Type,
+                        channelState.Channel.Id, new SendMessageRequest
+                        {
+                            Message = new MessageRequest
+                            {
+                                Text = nameof(channelState) + " #" + i
+                            }
+                        });
+
+                    yield return sendMessageTask.RunAsIEnumerator(messageResponse =>
+                    {
+                        onMessageSent?.Invoke((i, messageResponse));
+                    });
+                }
+            }
+
+            yield return Client.WaitForClientToConnect();
+
+            var channelType = "messaging";
+
+            ChannelState channelState1 = null;
+            ChannelState channelState2 = null;
+            ChannelState channelState3 = null;
+            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(),
+                state => channelState1 = state);
+            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(),
+                state => channelState2 = state);
+            yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(),
+                state => channelState3 = state);
+
+            //first is read -> 2 unread
+            var channelState1FirstMessageId = string.Empty;
+            yield return SendTestMessages(channelState1, response =>
+            {
+                if (response.Index == 0)
+                {
+                    channelState1FirstMessageId = response.MessageResponse.Message.Id;
+                }
+            });
+            //second is read -> 1 unread
+            var channelState2SecondMessageId = string.Empty;
+            yield return SendTestMessages(channelState2, response =>
+            {
+                if (response.Index == 1)
+                {
+                    channelState2SecondMessageId = response.MessageResponse.Message.Id;
+                }
+            });
+            //third is read -> 0 unread
+            var channelState3ThirdMessageId = string.Empty;
+            yield return SendTestMessages(channelState3, response =>
+            {
+                if (response.Index == 2)
+                {
+                    channelState3ThirdMessageId = response.MessageResponse.Message.Id;
+                }
+            });
+
+            var updateRequestBody = new UpdateChannelRequest
+            {
+                AddMembers = new List<ChannelMemberRequest>
+                {
+                    new ChannelMemberRequest
+                    {
+                        UserId = OtherUserId
+                    },
+                    new ChannelMemberRequest
+                    {
+                        UserId = Client.UserId
+                    }
+                }
+            };
+
+            //Join channels as members
+
+            var updateChannelTask =
+                Client.ChannelApi.UpdateChannelAsync(channelType, channelState1.Channel.Id, updateRequestBody);
+            yield return updateChannelTask.RunAsIEnumerator(response =>
+            {
+                Assert.AreEqual(channelType, response.Channel.Type);
+                Assert.IsTrue(response.Members.Any(_ => _.UserId == TestAdminId));
+            });
+
+            var updateChannelTask2 =
+                Client.ChannelApi.UpdateChannelAsync(channelType, channelState2.Channel.Id, updateRequestBody);
+            yield return updateChannelTask.RunAsIEnumerator(response =>
+            {
+                Assert.AreEqual(channelType, response.Channel.Type);
+                Assert.IsTrue(response.Members.Any(_ => _.UserId == TestAdminId));
+            });
+
+            var updateChannelTask3 =
+                Client.ChannelApi.UpdateChannelAsync(channelType, channelState3.Channel.Id, updateRequestBody);
+            yield return updateChannelTask.RunAsIEnumerator(response =>
+            {
+                Assert.AreEqual(channelType, response.Channel.Type);
+                Assert.IsTrue(response.Members.Any(_ => _.UserId == TestAdminId));
+            });
+
+            //Send mark read state
+
+            var markReadRequestTask = Client.ChannelApi.MarkReadAsync(new MarkChannelsReadRequest
+            {
+                ReadByChannel = new Dictionary<string, string>
+                {
+                    { channelState1.Channel.Cid, channelState1FirstMessageId },
+                    { channelState2.Channel.Cid, channelState2SecondMessageId },
+                    { channelState3.Channel.Cid, channelState3ThirdMessageId },
+                }
+            });
+
+            yield return markReadRequestTask.RunAsIEnumerator(markReadResponse => { });
+
+            //Query channels to confirm the read state
+
+            var queryChannelsTask = Client.ChannelApi.QueryChannelsAsync(new QueryChannelsRequest()
+            {
+                FilterConditions = new Dictionary<string, object>
+                {
+                    {
+                        "cid", new Dictionary<string, object>
+                        {
+                            {
+                                "$in",
+                                new[]
+                                {
+                                    channelState1.Channel.Cid, channelState2.Channel.Cid, channelState3.Channel.Cid
+                                }
+                            }
+                        }
+                    }
+                },
+            });
+
+            yield return queryChannelsTask.RunAsIEnumerator(channelsResponse =>
+            {
+                Assert.AreEqual(channelsResponse.Channels.Count, 3);
+
+                channelState1 = channelsResponse.Channels.FirstOrDefault(_ => _.Channel.Cid == channelState1.Channel.Cid);
+                channelState2 = channelsResponse.Channels.FirstOrDefault(_ => _.Channel.Cid == channelState2.Channel.Cid);
+                channelState3 = channelsResponse.Channels.FirstOrDefault(_ => _.Channel.Cid == channelState3.Channel.Cid);
+
+                Assert.NotNull(channelState1);
+                Assert.NotNull(channelState2);
+                Assert.NotNull(channelState3);
+
+                var localUserChannelState1ReadState =
+                    channelState1.Read.FirstOrDefault(_ => _.User.Id == Client.UserId);
+                var localUserChannelState2ReadState =
+                    channelState2.Read.FirstOrDefault(_ => _.User.Id == Client.UserId);
+                var localUserChannelState3ReadState =
+                    channelState3.Read.FirstOrDefault(_ => _.User.Id == Client.UserId);
+
+                Assert.NotNull(localUserChannelState1ReadState);
+                Assert.NotNull(localUserChannelState2ReadState);
+                Assert.NotNull(localUserChannelState3ReadState);
+
+                //Assert channel unread counts
+                Assert.AreEqual(localUserChannelState1ReadState.UnreadMessages, 2);
+                Assert.AreEqual(localUserChannelState2ReadState.UnreadMessages, 1);
+                Assert.AreEqual(localUserChannelState3ReadState.UnreadMessages, 0);
             });
         }
     }


### PR DESCRIPTION
### Read state purpose:
- control which messages are marked as read by users
- provide info on how many unread channels and messages user has
- get realtime notification on any change in this state


### How to change read state:
- `StreamChatClient.ChannelApi.MarkReadAsync` - mark read state for a single channel, if message ID is not provided the whole channel is considered as read
- `StreamChatClient.ChannelApi.MarkManyReadAsync` - mark ready state for a map of channel CID to last read message ID, if message ID is not provided the whole channel is considered as read

### How to retrieve read state:
- When client is connected the `StreamChatClient.LocalUser` will contain: `TotalUnreadCount`, `UnreadChannels` to give a summary of the unread state
- `StreamChatClient.ChannelApi.QueryChannelsAsync` response `ChannelState` contains list of `Read` states for each member with `UnreadMessages` and `LastRead` fields
- Subscibe to the following events in order to track realtime changes in the read state:
	- `StreamChatClient.MessageRead` - when a channel is marked as read. Triggered for users watching this channel
	- `StreamChatClient.NotificationMarkRead` - when the total count of unread messages (across all channels the user is a member) changes




