### PR TITLE
Feature/implement typing indicators

### DIFF
--- a/Assets/Plugins/StreamChat/Core/API/ApiClientBase.cs
+++ b/Assets/Plugins/StreamChat/Core/API/ApiClientBase.cs
@@ -4,10 +4,14 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using StreamChat.Core.DTO.Models;
+using StreamChat.Core.DTO.Requests;
+using StreamChat.Core.DTO.Responses;
 using StreamChat.Libs.Http;
 using StreamChat.Libs.Logs;
 using StreamChat.Libs.Serialization;
 using StreamChat.Core.Exceptions;
+using StreamChat.Core.Requests;
+using StreamChat.Core.Responses;
 using StreamChat.Core.Web;
 
 namespace StreamChat.Core.API
@@ -244,6 +248,14 @@ namespace StreamChat.Core.API
 
             return response;
         }
+
+        protected Task PostEventAsync<TEvent, TEventDto>(string channelType, string channelId, TEvent eventBody)
+            where TEvent : ISavableTo<TEventDto> =>
+            Post<SendEventRequest<TEvent, TEventDto>, SendEventRequestDTO, ApiResponse, ResponseDTO>(
+                $"/channels/{channelType}/{channelId}/event", new SendEventRequest<TEvent, TEventDto>
+                {
+                    Event = eventBody,
+                });
 
         protected void LogRestCall(Uri uri, string endpoint, HttpMethod httpMethod, string response, bool success, string request = null)
         {

--- a/Assets/Plugins/StreamChat/Core/API/ChannelApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/ChannelApi.cs
@@ -1,6 +1,8 @@
 ﻿using System.Threading.Tasks;
+using StreamChat.Core.DTO.Events;
 using StreamChat.Core.DTO.Requests;
 using StreamChat.Core.DTO.Responses;
+using StreamChat.Core.Events;
 using StreamChat.Libs.Http;
 using StreamChat.Libs.Logs;
 using StreamChat.Libs.Serialization;
@@ -150,5 +152,11 @@ namespace StreamChat.Core.API
         public Task<MarkReadResponse> MarkManyReadAsync(MarkChannelsReadRequest markChannelsReadRequest) =>
             Post<MarkChannelsReadRequest, MarkChannelsReadRequestDTO, MarkReadResponse, MarkReadResponseDTO>(
                 $"/channels/read", markChannelsReadRequest);
+
+        public Task SendTypingStartEventAsync(string channelType, string channelId)
+            => PostEventAsync<EventTypingStart, EventTypingStartDTO>(channelType, channelId, new EventTypingStart());
+
+        public Task SendTypingStopEventAsync(string channelType, string channelId)
+            => PostEventAsync<EventTypingStop, EventTypingStopDTO>(channelType, channelId, new EventTypingStop());
     }
 }

--- a/Assets/Plugins/StreamChat/Core/API/IChannelApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/IChannelApi.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using StreamChat.Core.Events;
 using StreamChat.Core.Models;
 using StreamChat.Core.Requests;
 using StreamChat.Core.Responses;
@@ -137,5 +138,9 @@ namespace StreamChat.Core.API
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/unity/unread_channel/?language=unity</remarks>
         Task<MarkReadResponse> MarkManyReadAsync(MarkChannelsReadRequest markChannelsReadRequest);
+
+        Task SendTypingStartEventAsync(string channelType, string channelId);
+
+        Task SendTypingStopEventAsync(string channelType, string channelId);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/DTO/Requests/SendEventRequestDTO.cs
+++ b/Assets/Plugins/StreamChat/Core/DTO/Requests/SendEventRequestDTO.cs
@@ -17,7 +17,7 @@ namespace StreamChat.Core.DTO.Requests
     internal partial class SendEventRequestDTO
     {
         [Newtonsoft.Json.JsonProperty("event", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public EventRequestDTO Event { get; set; } = new EventRequestDTO();
+        public object Event { get; set; }
 
         private System.Collections.Generic.Dictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
 

--- a/Assets/Plugins/StreamChat/Core/Events/EventTypingStart.cs
+++ b/Assets/Plugins/StreamChat/Core/Events/EventTypingStart.cs
@@ -1,0 +1,52 @@
+﻿using StreamChat.Core.DTO.Events;
+using StreamChat.Core.DTO.Models;
+using StreamChat.Core.Helpers;
+using StreamChat.Core.Models;
+
+namespace StreamChat.Core.Events
+{
+    public partial class EventTypingStart : EventBase, ILoadableFrom<EventTypingStartDTO, EventTypingStart>,
+        ISavableTo<EventTypingStartDTO>
+    {
+        public string ChannelId { get; set; }
+
+        public string ChannelType { get; set; }
+
+        public string Cid { get; set; }
+
+        public System.DateTimeOffset? CreatedAt { get; set; }
+
+        public string ParentId { get; set; }
+
+        public string Type { get; internal set; } = EventType.TypingStart;
+
+        public User User { get; internal set; }
+
+        EventTypingStart ILoadableFrom<EventTypingStartDTO, EventTypingStart>.LoadFromDto(EventTypingStartDTO dto)
+        {
+            ChannelId = dto.ChannelId;
+            ChannelType = dto.ChannelType;
+            Cid = dto.Cid;
+            CreatedAt = dto.CreatedAt;
+            ParentId = dto.ParentId;
+            Type = dto.Type;
+            User = User.TryLoadFromDto<UserObjectDTO, User>(dto.User);
+            AdditionalProperties = dto.AdditionalProperties;
+
+            return this;
+        }
+
+        EventTypingStartDTO ISavableTo<EventTypingStartDTO>.SaveToDto() =>
+            new EventTypingStartDTO
+            {
+                ChannelId = ChannelId,
+                ChannelType = ChannelType,
+                Cid = Cid,
+                CreatedAt = CreatedAt,
+                ParentId = ParentId,
+                Type = Type,
+                User = User.TrySaveToDto(),
+                AdditionalProperties = AdditionalProperties,
+            };
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Events/EventTypingStart.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Events/EventTypingStart.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b800ca78d2834d63b121915d05d943f8
+timeCreated: 1660775139

--- a/Assets/Plugins/StreamChat/Core/Events/EventTypingStop.cs
+++ b/Assets/Plugins/StreamChat/Core/Events/EventTypingStop.cs
@@ -1,0 +1,52 @@
+﻿using StreamChat.Core.DTO.Events;
+using StreamChat.Core.DTO.Models;
+using StreamChat.Core.Helpers;
+using StreamChat.Core.Models;
+
+namespace StreamChat.Core.Events
+{
+    public partial class EventTypingStop : EventBase, ILoadableFrom<EventTypingStopDTO, EventTypingStop>,
+        ISavableTo<EventTypingStopDTO>
+    {
+        public string ChannelId { get; set; }
+
+        public string ChannelType { get; set; }
+
+        public string Cid { get; set; }
+
+        public System.DateTimeOffset? CreatedAt { get; set; }
+
+        public string ParentId { get; set; }
+
+        public string Type { get; internal set; } = EventType.TypingStop;
+
+        public User User { get; internal set; }
+
+        EventTypingStop ILoadableFrom<EventTypingStopDTO, EventTypingStop>.LoadFromDto(EventTypingStopDTO dto)
+        {
+            AdditionalProperties = dto.AdditionalProperties;
+            ChannelId = dto.ChannelId;
+            ChannelType = dto.ChannelType;
+            Cid = dto.Cid;
+            CreatedAt = dto.CreatedAt;
+            ParentId = dto.ParentId;
+            Type = dto.Type;
+            User = User.TryLoadFromDto<UserObjectDTO, User>(dto.User);
+
+            return this;
+        }
+
+        EventTypingStopDTO ISavableTo<EventTypingStopDTO>.SaveToDto() =>
+            new EventTypingStopDTO
+            {
+                ChannelId = ChannelId,
+                ChannelType = ChannelType,
+                Cid = Cid,
+                CreatedAt = CreatedAt,
+                ParentId = ParentId,
+                Type = Type,
+                User = User.TrySaveToDto(),
+                AdditionalProperties = AdditionalProperties,
+            };
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Events/EventTypingStop.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Events/EventTypingStop.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 565578498dce400096498796e68e4047
+timeCreated: 1660775139

--- a/Assets/Plugins/StreamChat/Core/IStreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/IStreamChatClient.cs
@@ -39,6 +39,10 @@ namespace StreamChat.Core
         IUserApi UserApi { get; }
         OwnUser LocalUser { get; }
 
+        /// <summary>
+        /// Per frame update of the StreamChatClient. This method triggers sending and receiving data between the client and the server. Make sure to call it every frame.
+        /// </summary>
+        /// <param name="deltaTime"></param>
         void Update(float deltaTime);
 
         /// <summary>
@@ -51,6 +55,14 @@ namespace StreamChat.Core
 
         bool IsLocalUser(ChannelMember channelMember);
 
+        /// <summary>
+        /// Set parameters for StreamChatClient reconnect strategy
+        /// </summary>
+        /// <param name="reconnectStrategy">Defines how Client will react to Disconnected state</param>
+        /// <param name="exponentialMinInterval">Defines min reconnect interval for <see cref="StreamChat.Core.ReconnectStrategy.Exponential"/></param>
+        /// <param name="exponentialMaxInterval">Defines max reconnect interval for <see cref="StreamChat.Core.ReconnectStrategy.Exponential"/></param>
+        /// <param name="constantInterval">Defines reconnect interval for <see cref="StreamChat.Core.ReconnectStrategy.Constant"/></param>
+        /// <exception cref="ArgumentException">throws exception if intervals are less than or equal to zero</exception>
         void SetReconnectStrategySettings(ReconnectStrategy reconnectStrategy, float? exponentialMinInterval,
             float? exponentialMaxInterval, float? constantInterval);
     }

--- a/Assets/Plugins/StreamChat/Core/IStreamRealtimeEventsProvider.cs
+++ b/Assets/Plugins/StreamChat/Core/IStreamRealtimeEventsProvider.cs
@@ -85,5 +85,8 @@ namespace StreamChat.Core
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/unity/event_object/?language=unity</remarks>
         event Action<EventNotificationMessageNew> NotificationMessageReceived;
+
+        event Action<EventTypingStart> TypingStarted;
+        event Action<EventTypingStop> TypingStopped;
     }
 }

--- a/Assets/Plugins/StreamChat/Core/Requests/SendEventRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/Requests/SendEventRequest.cs
@@ -1,0 +1,17 @@
+﻿using StreamChat.Core.DTO.Requests;
+using StreamChat.Core.Events;
+
+namespace StreamChat.Core.Requests
+{
+    internal partial class SendEventRequest<TEvent, TEventDto>: EventBase, ISavableTo<SendEventRequestDTO>
+        where TEvent : ISavableTo<TEventDto>
+    {
+        public TEvent Event { get; set; }
+
+        SendEventRequestDTO ISavableTo<SendEventRequestDTO>.SaveToDto() =>
+            new SendEventRequestDTO
+            {
+                Event = Event.SaveToDto()
+            };
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Requests/SendEventRequest.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Requests/SendEventRequest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 26820d54734e45abaed841cb115353fd
+timeCreated: 1660829093

--- a/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
@@ -47,6 +47,9 @@ namespace StreamChat.Core
         public event Action<EventReactionUpdated> ReactionUpdated;
         public event Action<EventReactionDeleted> ReactionDeleted;
 
+        public event Action<EventTypingStart> TypingStarted;
+        public event Action<EventTypingStop> TypingStopped;
+
         public event Action<EventNotificationMarkRead> NotificationMarkRead;
         public event Action<EventNotificationMessageNew> NotificationMessageReceived;
 
@@ -209,14 +212,6 @@ namespace StreamChat.Core
         public bool IsLocalUser(ChannelMember channelMember)
             => channelMember.User.Id == _authCredentials.UserId;
 
-        /// <summary>
-        /// Set parameters for StreamChatClient reconnect strategy
-        /// </summary>
-        /// <param name="reconnectStrategy">Defines how Client will react to Disconnected state</param>
-        /// <param name="exponentialMinInterval">Defines min reconnect interval for <see cref="StreamChat.Core.ReconnectStrategy.Exponential"/></param>
-        /// <param name="exponentialMaxInterval">Defines max reconnect interval for <see cref="StreamChat.Core.ReconnectStrategy.Exponential"/></param>
-        /// <param name="constantInterval">Defines reconnect interval for <see cref="StreamChat.Core.ReconnectStrategy.Constant"/></param>
-        /// <exception cref="ArgumentException">throws exception if intervals are less than or equal to zero</exception>
         public void SetReconnectStrategySettings(ReconnectStrategy reconnectStrategy, float? exponentialMinInterval,
             float? exponentialMaxInterval, float? constantInterval)
         {
@@ -257,6 +252,12 @@ namespace StreamChat.Core
             _websocketClient.Connected -= OnWebsocketsConnected;
             _websocketClient.Disconnected -= OnWebsocketDisconnected;
             _websocketClient?.Dispose();
+        }
+
+        internal void SendEvent<TEventType, TDto>(TEventType eventBody)
+            where TEventType : EventBase, ISavableTo<TDto>
+        {
+            _websocketClient.Send(_serializer.Serialize(eventBody.SaveToDto()));
         }
 
         string IAuthProvider.ApiKey => _authCredentials.ApiKey;
@@ -427,6 +428,11 @@ namespace StreamChat.Core
             RegisterEventType<EventReactionDeletedDTO, EventReactionDeleted>(EventType.ReactionDeleted,
                 e => ReactionDeleted?.Invoke(e));
 
+            RegisterEventType<EventTypingStartDTO, EventTypingStart>(EventType.TypingStart,
+                e => TypingStarted?.Invoke(e));
+            RegisterEventType<EventTypingStopDTO, EventTypingStop>(EventType.TypingStop,
+                e => TypingStopped?.Invoke(e));
+
             RegisterEventType<EventMessageReadDTO, EventMessageRead>(EventType.MessageRead,
                 e => MessageRead?.Invoke(e));
             RegisterEventType<EventNotificationMarkReadDTO, EventNotificationMarkRead>(EventType.NotificationMarkRead,
@@ -498,7 +504,7 @@ namespace StreamChat.Core
 
             if (!_eventKeyToHandler.TryGetValue(type, out var handler))
             {
-                //_logs.Warning($"No message handler registered for `{type}`. Message not handled: " + msg);
+                _logs.Warning($"No message handler registered for `{type}`. Message not handled: " + msg);
                 return;
             }
 

--- a/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
@@ -254,12 +254,6 @@ namespace StreamChat.Core
             _websocketClient?.Dispose();
         }
 
-        internal void SendEvent<TEventType, TDto>(TEventType eventBody)
-            where TEventType : EventBase, ISavableTo<TDto>
-        {
-            _websocketClient.Send(_serializer.Serialize(eventBody.SaveToDto()));
-        }
-
         string IAuthProvider.ApiKey => _authCredentials.ApiKey;
         string IAuthProvider.UserToken => _authCredentials.UserToken;
         string IAuthProvider.UserId => _authCredentials.UserId;
@@ -504,7 +498,7 @@ namespace StreamChat.Core
 
             if (!_eventKeyToHandler.TryGetValue(type, out var handler))
             {
-                _logs.Warning($"No message handler registered for `{type}`. Message not handled: " + msg);
+                //_logs.Warning($"No message handler registered for `{type}`. Message not handled: " + msg);
                 return;
             }
 

--- a/Assets/Plugins/StreamChat/SampleProject/Prefabs/StreamChatInstance.prefab
+++ b/Assets/Plugins/StreamChat/SampleProject/Prefabs/StreamChatInstance.prefab
@@ -597,7 +597,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 941931286955265189, guid: cf8b5ddfc547e26408e3b35375ee32e6, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 120
       objectReference: {fileID: 0}
     - target: {fileID: 941931286955265189, guid: cf8b5ddfc547e26408e3b35375ee32e6, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -705,7 +705,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1804968517769851866, guid: cf8b5ddfc547e26408e3b35375ee32e6, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 620
       objectReference: {fileID: 0}
     - target: {fileID: 1804968517769851866, guid: cf8b5ddfc547e26408e3b35375ee32e6, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -743,6 +743,10 @@ PrefabInstance:
       propertyPath: m_Size
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4745333681441547675, guid: cf8b5ddfc547e26408e3b35375ee32e6, type: 3}
+      propertyPath: m_Value
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5175795723190653869, guid: cf8b5ddfc547e26408e3b35375ee32e6, type: 3}
       propertyPath: m_Name
       value: ChannelHeaderView
@@ -775,6 +779,10 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7291035790777009688, guid: cf8b5ddfc547e26408e3b35375ee32e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 40
+      objectReference: {fileID: 0}
     - target: {fileID: 7690220340430243259, guid: cf8b5ddfc547e26408e3b35375ee32e6, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -789,7 +797,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7690220340430243259, guid: cf8b5ddfc547e26408e3b35375ee32e6, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 7690220340430243259, guid: cf8b5ddfc547e26408e3b35375ee32e6, type: 3}
       propertyPath: m_AnchoredPosition.x

--- a/Assets/Plugins/StreamChat/SampleProject/Prefabs/StreamChatInstance.prefab
+++ b/Assets/Plugins/StreamChat/SampleProject/Prefabs/StreamChatInstance.prefab
@@ -28,7 +28,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5251248261986067130}
   m_RootOrder: 1
@@ -95,7 +94,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4992558259838702947}
   - {fileID: 3859440365551572142}
@@ -173,7 +171,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2399418190667376220}
   m_RootOrder: 2
@@ -230,7 +227,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2740502489586438664}
   - {fileID: 826664473}
@@ -253,7 +249,6 @@ MonoBehaviour:
   _authCredentialsAsset: {fileID: 11400000, guid: 0b08ddaef6283734185d71ce00304d5d, type: 2}
   _appConfig: {fileID: 11400000, guid: 0974ede686fa6da4b96d526edea9fbbd, type: 2}
   _popupsContainer: {fileID: 5034016418571902947}
-  _tmpSpriteAsset: {fileID: 11400000, guid: baf066641327b9143b99e56db7a47f8c, type: 2}
 --- !u!1 &7002968776139178785
 GameObject:
   m_ObjectHideFlags: 0
@@ -283,7 +278,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2399418190667376220}
   m_Father: {fileID: 5251248261986067130}
@@ -418,6 +412,10 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4574243906138088508, guid: 912b3fd8bdee29948ae2fae63263c2fd, type: 3}
+      propertyPath: m_Value
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5288295112417952834, guid: 912b3fd8bdee29948ae2fae63263c2fd, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -532,7 +530,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8479839043950096287, guid: 912b3fd8bdee29948ae2fae63263c2fd, type: 3}
       propertyPath: m_Size
-      value: 0.99999183
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8479839043950096287, guid: 912b3fd8bdee29948ae2fae63263c2fd, type: 3}
       propertyPath: m_Value
@@ -540,6 +538,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 912b3fd8bdee29948ae2fae63263c2fd, type: 3}
+--- !u!224 &4992558259838702947 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6393041876404412600, guid: 912b3fd8bdee29948ae2fae63263c2fd, type: 3}
+  m_PrefabInstance: {fileID: 2157651931054011867}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1390955526517171451 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1061774539375300896, guid: 912b3fd8bdee29948ae2fae63263c2fd, type: 3}
@@ -565,11 +568,6 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
---- !u!224 &4992558259838702947 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6393041876404412600, guid: 912b3fd8bdee29948ae2fae63263c2fd, type: 3}
-  m_PrefabInstance: {fileID: 2157651931054011867}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3310961426347143866
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -743,7 +741,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4745333681441547675, guid: cf8b5ddfc547e26408e3b35375ee32e6, type: 3}
       propertyPath: m_Size
-      value: 0.99998826
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175795723190653869, guid: cf8b5ddfc547e26408e3b35375ee32e6, type: 3}
+      propertyPath: m_Name
+      value: ChannelHeaderView
       objectReference: {fileID: 0}
     - target: {fileID: 5932003826525095005, guid: cf8b5ddfc547e26408e3b35375ee32e6, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/Plugins/StreamChat/SampleProject/Prefabs/UI/ChannelHeaderView.prefab
+++ b/Assets/Plugins/StreamChat/SampleProject/Prefabs/UI/ChannelHeaderView.prefab
@@ -1,0 +1,186 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2694065857651031273
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 547704374733023580}
+  - component: {fileID: 1397852439148600428}
+  m_Layer: 5
+  m_Name: ChannelHeaderView
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &547704374733023580
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2694065857651031273}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2579880222067287816}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &1397852439148600428
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2694065857651031273}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af2439e37c312854f8dcf764e5b05747, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _typingNotificationText: {fileID: 407929294184328722}
+--- !u!1 &2722702198758486045
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2579880222067287816}
+  - component: {fileID: 5013440894082264345}
+  - component: {fileID: 407929294184328722}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2579880222067287816
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2722702198758486045}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 547704374733023580}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5013440894082264345
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2722702198758486045}
+  m_CullTransparentMesh: 1
+--- !u!114 &407929294184328722
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2722702198758486045}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Steven, Mitch and Kenny are typing...
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 18
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}

--- a/Assets/Plugins/StreamChat/SampleProject/Prefabs/UI/ChannelHeaderView.prefab.meta
+++ b/Assets/Plugins/StreamChat/SampleProject/Prefabs/UI/ChannelHeaderView.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 26ae6bec48b46d74d8162fc53beefcf3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/StreamChat/SampleProject/Prefabs/UI/Message/MessageInputView.prefab
+++ b/Assets/Plugins/StreamChat/SampleProject/Prefabs/UI/Message/MessageInputView.prefab
@@ -29,7 +29,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6660553918833310373}
   m_RootOrder: 0
@@ -168,6 +167,7 @@ GameObject:
   - component: {fileID: 6312814017620200531}
   - component: {fileID: 3630980759929417957}
   - component: {fileID: 7402016827450285766}
+  - component: {fileID: 2406293566404746739}
   m_Layer: 5
   m_Name: InputField (TMP)
   m_TagString: Untagged
@@ -185,7 +185,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6660553918833310373}
   m_Father: {fileID: 1008468584739597727}
@@ -332,6 +331,26 @@ MonoBehaviour:
   m_isRichTextEditingAllowed: 0
   m_LineLimit: 0
   m_InputValidator: {fileID: 0}
+--- !u!114 &2406293566404746739
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3214192908772934372}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: 50
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &4708488478532143380
 GameObject:
   m_ObjectHideFlags: 0
@@ -361,7 +380,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4513036174685458404}
   m_Father: {fileID: 1008468584739597727}
@@ -482,7 +500,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6660553918833310373}
   m_RootOrder: 1
@@ -618,7 +635,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3025080780265695999}
   m_Father: {fileID: 1008468584739597727}
@@ -739,7 +755,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8772903475831237434}
   m_RootOrder: 0
@@ -873,7 +888,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 630880277305362978}
   - {fileID: 8312995644134628072}
@@ -926,7 +940,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 214380346822597035}
   - {fileID: 1978342806195699617}
@@ -982,7 +995,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1978342806195699617}
   m_RootOrder: 0

--- a/Assets/Plugins/StreamChat/SampleProject/Prefabs/UI/RightColumn.prefab
+++ b/Assets/Plugins/StreamChat/SampleProject/Prefabs/UI/RightColumn.prefab
@@ -28,8 +28,8 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 7291035790777009688}
   - {fileID: 1804968517769851866}
   - {fileID: 941931286955265189}
   - {fileID: 7690220340430243259}
@@ -104,7 +104,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1008468584739597727, guid: a8ff724b108472b41ae3441105023981, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1008468584739597727, guid: a8ff724b108472b41ae3441105023981, type: 3}
       propertyPath: m_AnchorMax.x
@@ -206,7 +206,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 79697601131101729, guid: 7c6239b49c8b04342a536025edd61366, type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 79697601131101729, guid: 7c6239b49c8b04342a536025edd61366, type: 3}
       propertyPath: m_AnchorMax.x
@@ -362,14 +362,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c6239b49c8b04342a536025edd61366, type: 3}
---- !u!224 &1804968517769851866 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 79697601131101729, guid: 7c6239b49c8b04342a536025edd61366, type: 3}
-  m_PrefabInstance: {fileID: 1736047247301398011}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &5770480915610160850 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5189114443080696617, guid: 7c6239b49c8b04342a536025edd61366, type: 3}
+  m_PrefabInstance: {fileID: 1736047247301398011}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1804968517769851866 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 79697601131101729, guid: 7c6239b49c8b04342a536025edd61366, type: 3}
   m_PrefabInstance: {fileID: 1736047247301398011}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &1586316124190470485
@@ -433,7 +433,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2620233721520906948, guid: 52e5878015a478a48b3dee2946655058, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2620233721520906948, guid: 52e5878015a478a48b3dee2946655058, type: 3}
       propertyPath: m_AnchorMax.x
@@ -517,4 +517,106 @@ PrefabInstance:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2620233721520906948, guid: 52e5878015a478a48b3dee2946655058, type: 3}
   m_PrefabInstance: {fileID: 5685185435883857791}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7113189690329526084
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1764735337309955604}
+    m_Modifications:
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2694065857651031273, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+      propertyPath: m_Name
+      value: TypingNotificationView
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+--- !u!224 &7291035790777009688 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
+  m_PrefabInstance: {fileID: 7113189690329526084}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Plugins/StreamChat/SampleProject/Prefabs/UI/RightColumn.prefab
+++ b/Assets/Plugins/StreamChat/SampleProject/Prefabs/UI/RightColumn.prefab
@@ -83,7 +83,7 @@ MonoBehaviour:
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 1
-  m_ChildControlHeight: 1
+  m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
@@ -128,7 +128,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1008468584739597727, guid: a8ff724b108472b41ae3441105023981, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 88.89909
       objectReference: {fileID: 0}
     - target: {fileID: 1008468584739597727, guid: a8ff724b108472b41ae3441105023981, type: 3}
       propertyPath: m_LocalPosition.x
@@ -230,7 +230,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 79697601131101729, guid: 7c6239b49c8b04342a536025edd61366, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 588.8991
       objectReference: {fileID: 0}
     - target: {fileID: 79697601131101729, guid: 7c6239b49c8b04342a536025edd61366, type: 3}
       propertyPath: m_LocalPosition.x
@@ -457,7 +457,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2620233721520906948, guid: 52e5878015a478a48b3dee2946655058, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 88.89909
       objectReference: {fileID: 0}
     - target: {fileID: 2620233721520906948, guid: 52e5878015a478a48b3dee2946655058, type: 3}
       propertyPath: m_LocalPosition.x
@@ -559,7 +559,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 547704374733023580, guid: 26ae6bec48b46d74d8162fc53beefcf3, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Plugins/StreamChat/SampleProject/Scripts/ChatState.cs
+++ b/Assets/Plugins/StreamChat/SampleProject/Scripts/ChatState.cs
@@ -62,6 +62,9 @@ namespace StreamChat.SampleProject
             Client.ReactionUpdated += OnReactionUpdated;
             Client.ReactionDeleted += OnReactionDeleted;
 
+            Client.TypingStarted += OnTypingStarted;
+            Client.TypingStopped += OnTypingStopped;
+
             Client.NotificationMarkRead += OnNotificationMarkRead;
         }
 
@@ -76,6 +79,9 @@ namespace StreamChat.SampleProject
             Client.ReactionReceived -= OnReactionReceived;
             Client.ReactionUpdated -= OnReactionUpdated;
             Client.ReactionDeleted -= OnReactionDeleted;
+
+            Client.TypingStarted -= OnTypingStarted;
+            Client.TypingStopped -= OnTypingStopped;
 
             Client.NotificationMarkRead -= OnNotificationMarkRead;
 
@@ -313,6 +319,16 @@ namespace StreamChat.SampleProject
 
         private void OnReactionUpdated(EventReactionUpdated eventReactionUpdated) =>
             UpdateChannelMessage(eventReactionUpdated.Message);
+
+        private void OnTypingStarted(EventTypingStart obj)
+        {
+            Debug.Log($"OnTypingStarted - CID: {obj.Cid}, User: {obj.User.Id}, Created at: {obj.CreatedAt}");
+        }
+
+        private void OnTypingStopped(EventTypingStop obj)
+        {
+            Debug.Log($"OnTypingStopped - CID: {obj.Cid}, User: {obj.User.Id}, Created at: {obj.CreatedAt}");
+        }
 
         private void OnNotificationMarkRead(EventNotificationMarkRead eventNotificationMarkRead) =>
             Debug.Log($"Notified mark read for channel: {eventNotificationMarkRead.Cid}, " +

--- a/Assets/Plugins/StreamChat/SampleProject/Scripts/TypingMonitor.cs
+++ b/Assets/Plugins/StreamChat/SampleProject/Scripts/TypingMonitor.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using StreamChat.Core;
+using StreamChat.Core.Events;
+using StreamChat.Core.Models;
+using TMPro;
+using UnityEngine;
+
+namespace StreamChat.SampleProject
+{
+    public class TypingMonitor : IDisposable
+    {
+        public TypingMonitor(TMP_InputField source, IStreamChatClient client, IChatState chatState, Func<bool> isActive)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _source = source ?? throw new ArgumentNullException(nameof(source));
+            _chatState = chatState ?? throw new ArgumentNullException(nameof(chatState));
+            _isActive = isActive ?? throw new ArgumentNullException(nameof(isActive));
+
+            _source.onValueChanged.AddListener(OnInputValueChanged);
+        }
+
+        public void Update()
+        {
+            for (int i = _startedTypingChannels.Count - 1; i >= 0; i--)
+            {
+                var channel = _startedTypingChannels[i];
+
+                if (!_channelCidToTypingStartEventSentTime.TryGetValue(channel.Cid, out var eventSentTime))
+                {
+                    Debug.LogWarning($"Tried to send typing.stop event but channel CId `{channel}` was not found");
+                    _startedTypingChannels.RemoveAt(i);
+                    continue;
+                }
+
+                if (Time.time - eventSentTime > TypingStopEventTimeout)
+                {
+                    TrySendStopTypingEvent(channel);
+                }
+            }
+        }
+
+        public void NotifyChannelStoppedTyping(Channel channel)
+            => TrySendStopTypingEvent(channel);
+
+        public void Dispose()
+        {
+            _source.onValueChanged.RemoveListener(OnInputValueChanged);
+        }
+
+        /// <summary>
+        /// Minimum interval to send the typing.start event per channel
+        /// </summary>
+        private const float TypingStartEventThrottleInterval = 2;
+
+        /// <summary>
+        /// Timeout after typing has stopped to send the typing.stop event
+        /// </summary>
+        private const float TypingStopEventTimeout = 15;
+
+        private readonly TMP_InputField _source;
+        private readonly IStreamChatClient _client;
+        private readonly Func<bool> _isActive;
+        private readonly IChatState _chatState;
+
+        private readonly Dictionary<string, float> _channelCidToTypingStartEventSentTime =
+            new Dictionary<string, float>();
+
+        private readonly List<Channel> _startedTypingChannels = new List<Channel>();
+
+        private void OnInputValueChanged(string text)
+        {
+            if (!_isActive())
+            {
+                return;
+            }
+
+            var activeChannel = _chatState.ActiveChannel.Channel;
+
+            TrySendStartTypingEvent(activeChannel);
+        }
+
+        private void TrySendStartTypingEvent(Channel channel)
+        {
+            if (_channelCidToTypingStartEventSentTime.TryGetValue(channel.Cid, out var typingStartSentTime) &&
+                Time.time - typingStartSentTime < TypingStartEventThrottleInterval)
+            {
+                return;
+            }
+
+            _client.ChannelApi.SendTypingStartEventAsync(channel.Type, channel.Id);
+
+            if (!_channelCidToTypingStartEventSentTime.ContainsKey(channel.Cid))
+            {
+                _startedTypingChannels.Add(channel);
+            }
+
+            _channelCidToTypingStartEventSentTime[channel.Cid] = Time.time;
+        }
+
+        private void TrySendStopTypingEvent(Channel channel)
+        {
+            if (!_channelCidToTypingStartEventSentTime.ContainsKey(channel.Cid))
+            {
+                return;
+            }
+
+            _client.ChannelApi.SendTypingStopEventAsync(channel.Type, channel.Id);
+
+            _channelCidToTypingStartEventSentTime.Remove(channel.Cid);
+
+            for (int i = _startedTypingChannels.Count - 1; i >= 0; i--)
+            {
+                if (_startedTypingChannels[i].Cid == channel.Cid)
+                {
+                    _startedTypingChannels.RemoveAt(i);
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/SampleProject/Scripts/TypingMonitor.cs
+++ b/Assets/Plugins/StreamChat/SampleProject/Scripts/TypingMonitor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using StreamChat.Core;
-using StreamChat.Core.Events;
 using StreamChat.Core.Models;
 using TMPro;
 using UnityEngine;

--- a/Assets/Plugins/StreamChat/SampleProject/Scripts/TypingMonitor.cs.meta
+++ b/Assets/Plugins/StreamChat/SampleProject/Scripts/TypingMonitor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1139248e14394425a5fac5f3aae2fdc7
+timeCreated: 1660818751

--- a/Assets/Plugins/StreamChat/SampleProject/Scripts/Views/ChannelHeaderView.cs
+++ b/Assets/Plugins/StreamChat/SampleProject/Scripts/Views/ChannelHeaderView.cs
@@ -1,0 +1,120 @@
+using System.Collections.Generic;
+using System.Text;
+using StreamChat.Core.Events;
+using TMPro;
+using UnityEngine;
+
+namespace StreamChat.SampleProject.Views
+{
+    /// <summary>
+    /// Active channel header
+    /// </summary>
+    public class ChannelHeaderView : BaseView
+    {
+        protected override void OnInited()
+        {
+            base.OnInited();
+
+            Client.TypingStarted += OnTypingStarted;
+            Client.TypingStopped += OnTypingStopped;
+        }
+
+        protected override void OnUpdate()
+        {
+            base.OnUpdate();
+
+            if (Time.time - _lastUpdateTime > UpdateInterval)
+            {
+                UpdateTypingUsersPreview();
+            }
+        }
+
+        protected override void OnDisposing()
+        {
+            Client.TypingStarted -= OnTypingStarted;
+            Client.TypingStopped -= OnTypingStopped;
+
+            base.OnDisposing();
+        }
+
+        private void OnTypingStopped(EventTypingStop obj)
+        {
+            if (!_channelCidToTypingUserIds.ContainsKey(obj.Cid))
+            {
+                return;
+            }
+
+            _channelCidToTypingUserIds[obj.Cid].Remove(obj.User.Id);
+
+            if (!_channelCidToTypingUserIds.TryGetValue(obj.Cid, out var users))
+            {
+                _channelCidToTypingUserIds[obj.Cid] = new HashSet<string>();
+            }
+        }
+
+        private void OnTypingStarted(EventTypingStart obj)
+        {
+            if (!_channelCidToTypingUserIds.TryGetValue(obj.Cid, out var userIds))
+            {
+                _channelCidToTypingUserIds[obj.Cid] = new HashSet<string>();
+            }
+
+            userIds.Add(obj.User.Id);
+        }
+
+        private const float UpdateInterval = 0.3f;
+
+        private readonly StringBuilder _sb = new StringBuilder();
+        private readonly Dictionary<string, HashSet<string>> _channelCidToTypingUserIds =
+            new Dictionary<string, HashSet<string>>();
+
+        [SerializeField]
+        private TMP_Text _typingNotificationText;
+
+        private int _step;
+        private float _lastUpdateTime;
+
+        private void UpdateTypingUsersPreview()
+        {
+            if (State.ActiveChannel == null ||
+                !_channelCidToTypingUserIds.TryGetValue(State.ActiveChannel.Channel.Cid, out var typingUsers))
+            {
+                return;
+            }
+
+            var index = 0;
+            var isSingle = typingUsers.Count == 1;
+            foreach (var userId in typingUsers)
+            {
+                var isLast = index == typingUsers.Count - 1;
+                var isNextLast = !isLast && index == typingUsers.Count - 2;
+                _sb.Append(userId);
+
+                if (!isLast && !isNextLast)
+                {
+                    _sb.Append(", ");
+                }
+                if (isNextLast)
+                {
+                    _sb.Append(" and ");
+                }
+
+                if (isLast)
+                {
+                    _sb.Append(isSingle ? " is typing" : " are typing");
+
+                    var dotsCount = _step % 3;
+                    _sb.Append(new string('.', dotsCount));
+                }
+
+                index++;
+            }
+
+            _lastUpdateTime = Time.time;
+            _step++;
+
+            _typingNotificationText.text = _sb.ToString();
+            _sb.Clear();
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/SampleProject/Scripts/Views/ChannelHeaderView.cs
+++ b/Assets/Plugins/StreamChat/SampleProject/Scripts/Views/ChannelHeaderView.cs
@@ -11,6 +11,11 @@ namespace StreamChat.SampleProject.Views
     /// </summary>
     public class ChannelHeaderView : BaseView
     {
+        protected void Awake()
+        {
+            _typingNotificationText.text = string.Empty;
+        }
+
         protected override void OnInited()
         {
             base.OnInited();
@@ -103,7 +108,7 @@ namespace StreamChat.SampleProject.Views
                 {
                     _sb.Append(isSingle ? " is typing" : " are typing");
 
-                    var dotsCount = _step % 3;
+                    var dotsCount = _step % 4;
                     _sb.Append(new string('.', dotsCount));
                 }
 

--- a/Assets/Plugins/StreamChat/SampleProject/Scripts/Views/ChannelHeaderView.cs.meta
+++ b/Assets/Plugins/StreamChat/SampleProject/Scripts/Views/ChannelHeaderView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af2439e37c312854f8dcf764e5b05747
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/StreamChat/SampleProject/Scripts/Views/ConsoleView.cs
+++ b/Assets/Plugins/StreamChat/SampleProject/Scripts/Views/ConsoleView.cs
@@ -13,6 +13,11 @@ namespace StreamChat.SampleProject.Views
     /// </summary>
     public class ConsoleView : BaseView
     {
+        protected void Awake()
+        {
+            _prevNetworkReachability = Application.internetReachability;
+        }
+
         protected override void OnInited()
         {
             base.OnInited();

--- a/StreamChat.SampleProject.csproj.DotSettings
+++ b/StreamChat.SampleProject.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cplugins_005Cstreamchat_005Csampleproject_005Cscripts/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
### Summary:
Typing indicators allow for showing in real time which users are currently typing a message on a channel. Just like it works on Whatsapp or Facebook Messenger.  

### How to send typing indicator:
- Use `StreamChatClient.ChannelApi.SendTypingStartEventAsync`  to notify watchers that the local user is typing a message 
- Use `StreamChatClient.ChannelApi.SendTypingStopEventAsync` to notify watchers that the local user has stopped typing

### How to receive typing notifications:
- Subscribe to `StreamChatClient.TypingStarted` & `StreamChatClient.TypingStopped` events

### Best practices:
- It is sufficient to send the `typing.start` event every few seconds. Sending it on every keystroke would generate excessive network traffic
- Send the `typing.stop` event after timeout (15-40 seconds) when user stopped typing or immediately after the message is sent

### Example integration:
- `Assets/Plugins/StreamChat/SampleProject/Scripts/TypingMonitor.cs` - coordinates sending start/stop typing events per each channel
	- sending `typing.start` event is throttled and not sent more often than every 2 seconds
	- `typing.stop` event is sent either when the user sends the message or when 15 seconds timeout has passed
- `Assets/Plugins/StreamChat/SampleProject/Scripts/Views/ChannelHeaderView.cs` - UI logic that maintains a list of currently typing users and concatenates into "Steven, Kelly and Mike are typing..." form