### PR TITLE
Feature/implement search messages endpoint

### DIFF
--- a/Assets/Plugins/StreamChat/Core/API/IMessageApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/IMessageApi.cs
@@ -59,5 +59,13 @@ namespace StreamChat.Core.API
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/unity/file_uploads/?language=unity</remarks>
         Task<FileDeleteResponse> DeleteFileAsync(string channelType, string channelId, string fileUrl);
+
+        /// <summary>
+        /// <para>Search messages</para>
+        /// You can enable and/or disable the search indexing on a per channel
+        /// type through the Stream Dashboard.
+        /// </summary>
+        /// <remarks>https://getstream.io/chat/docs/unity/search/?language=unity</remarks>
+        Task<SearchResponse> SearchMessagesAsync(SearchRequest searchRequest);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/API/MessageApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/MessageApi.cs
@@ -77,5 +77,8 @@ namespace StreamChat.Core.API
 
             return Delete<FileDeleteResponse, FileDeleteResponseDTO>(endpoint, parameters);
         }
+
+        public Task<SearchResponse> SearchMessagesAsync(SearchRequest searchRequest)
+            => Get<SearchRequest, SearchRequestDTO, SearchResponse, SearchResponseDTO>("/search", searchRequest);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/DTO/Requests/SearchRequestDTO.cs
+++ b/Assets/Plugins/StreamChat/Core/DTO/Requests/SearchRequestDTO.cs
@@ -26,7 +26,7 @@ namespace StreamChat.Core.DTO.Requests
         /// Number of messages to return
         /// </summary>
         [Newtonsoft.Json.JsonProperty("limit", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public double? Limit { get; set; }
+        public int? Limit { get; set; }
 
         /// <summary>
         /// Message filter conditions
@@ -44,7 +44,7 @@ namespace StreamChat.Core.DTO.Requests
         /// Pagination offset. Cannot be used with sort or next.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("offset", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public double? Offset { get; set; }
+        public int? Offset { get; set; }
 
         /// <summary>
         /// Search phrase

--- a/Assets/Plugins/StreamChat/Core/DTO/Responses/SearchResultMessageDTO.cs
+++ b/Assets/Plugins/StreamChat/Core/DTO/Responses/SearchResultMessageDTO.cs
@@ -149,13 +149,13 @@ namespace StreamChat.Core.DTO.Responses
         /// An object containing number of reactions of each type. Key: reaction type (string), value: number of reactions (int)
         /// </summary>
         [Newtonsoft.Json.JsonProperty("reaction_counts", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.Dictionary<string, double> ReactionCounts { get; set; }
+        public System.Collections.Generic.Dictionary<string, int> ReactionCounts { get; set; }
 
         /// <summary>
         /// An object containing scores of reactions of each type. Key: reaction type (string), value: total score of reactions (int)
         /// </summary>
         [Newtonsoft.Json.JsonProperty("reaction_scores", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.Dictionary<string, double> ReactionScores { get; set; }
+        public System.Collections.Generic.Dictionary<string, int> ReactionScores { get; set; }
 
         /// <summary>
         /// Number of replies to this message

--- a/Assets/Plugins/StreamChat/Core/Events/EventMessageDeleted.cs
+++ b/Assets/Plugins/StreamChat/Core/Events/EventMessageDeleted.cs
@@ -34,7 +34,7 @@ namespace StreamChat.Core.Events
             Cid = dto.Cid;
             CreatedAt = dto.CreatedAt;
             HardDelete = dto.HardDelete;
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             Team = dto.Team;
             ThreadParticipants = ThreadParticipants.TryLoadFromDtoCollection(dto.ThreadParticipants);
             Type = dto.Type;

--- a/Assets/Plugins/StreamChat/Core/Events/EventMessageFlagged.cs
+++ b/Assets/Plugins/StreamChat/Core/Events/EventMessageFlagged.cs
@@ -23,7 +23,7 @@ namespace StreamChat.Core.Events
         {
             Cid = dto.Cid;
             CreatedAt = dto.CreatedAt;
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             ThreadParticipants = ThreadParticipants.TryLoadFromDtoCollection(dto.ThreadParticipants);
             Type = dto.Type;
             User = User.TryLoadFromDto<UserObjectDTO, User>(dto.User);

--- a/Assets/Plugins/StreamChat/Core/Events/EventMessageNew.cs
+++ b/Assets/Plugins/StreamChat/Core/Events/EventMessageNew.cs
@@ -39,7 +39,7 @@ namespace StreamChat.Core.Events
             ChannelType = dto.ChannelType;
             Cid = dto.Cid;
             CreatedAt = dto.CreatedAt;
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             Team = dto.Team;
             ThreadParticipants = ThreadParticipants.TryLoadFromDtoCollection(dto.ThreadParticipants);
             Type = dto.Type;

--- a/Assets/Plugins/StreamChat/Core/Events/EventMessageUpdated.cs
+++ b/Assets/Plugins/StreamChat/Core/Events/EventMessageUpdated.cs
@@ -31,7 +31,7 @@ namespace StreamChat.Core.Events
             ChannelType = dto.ChannelType;
             Cid = dto.Cid;
             CreatedAt = dto.CreatedAt;
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             Team = dto.Team;
             ThreadParticipants = ThreadParticipants.TryLoadFromDtoCollection(dto.ThreadParticipants);
             Type = dto.Type;

--- a/Assets/Plugins/StreamChat/Core/Events/EventNotificationMessageNew.cs
+++ b/Assets/Plugins/StreamChat/Core/Events/EventNotificationMessageNew.cs
@@ -37,7 +37,7 @@ namespace StreamChat.Core.Events
             ChannelType = dto.ChannelType;
             Cid = dto.Cid;
             CreatedAt = dto.CreatedAt;
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             Team = dto.Team;
             Type = dto.Type;
             TotalUnreadCount = dto.TotalUnreadCount;

--- a/Assets/Plugins/StreamChat/Core/Events/EventReactionDeleted.cs
+++ b/Assets/Plugins/StreamChat/Core/Events/EventReactionDeleted.cs
@@ -33,7 +33,7 @@ namespace StreamChat.Core.Events
             ChannelType = dto.ChannelType;
             Cid = dto.Cid;
             CreatedAt = dto.CreatedAt;
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             Reaction = Reaction.TryLoadFromDto(dto.Reaction);
             Team = dto.Team;
             ThreadParticipants = ThreadParticipants.TryLoadFromDtoCollection(dto.ThreadParticipants);

--- a/Assets/Plugins/StreamChat/Core/Events/EventReactionNew.cs
+++ b/Assets/Plugins/StreamChat/Core/Events/EventReactionNew.cs
@@ -33,7 +33,7 @@ namespace StreamChat.Core.Events
             ChannelType = dto.ChannelType;
             Cid = dto.Cid;
             CreatedAt = dto.CreatedAt;
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             Reaction = Reaction.TryLoadFromDto(dto.Reaction);
             Team = dto.Team;
             ThreadParticipants = ThreadParticipants.TryLoadFromDtoCollection(dto.ThreadParticipants);

--- a/Assets/Plugins/StreamChat/Core/Events/EventReactionUpdated.cs
+++ b/Assets/Plugins/StreamChat/Core/Events/EventReactionUpdated.cs
@@ -31,7 +31,7 @@ namespace StreamChat.Core.Events
             ChannelType = dto.ChannelType;
             Cid = dto.Cid;
             CreatedAt = dto.CreatedAt;
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             Reaction = Reaction.TryLoadFromDto(dto.Reaction);
             Team = dto.Team;
             Type = dto.Type;

--- a/Assets/Plugins/StreamChat/Core/Models/Message.cs
+++ b/Assets/Plugins/StreamChat/Core/Models/Message.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using StreamChat.Core.DTO.Models;
+using StreamChat.Core.DTO.Responses;
 using StreamChat.Core.Helpers;
 
 namespace StreamChat.Core.Models
 {
-    public class Message : ModelBase, ILoadableFrom<MessageDTO, Message>
+    public class Message : ModelBase, ILoadableFrom<MessageDTO, Message>, ILoadableFrom<SearchResultMessageDTO, Message>
     {
         /// <summary>
         /// Array of message attachments
@@ -16,6 +17,11 @@ namespace StreamChat.Core.Models
         /// Whether `before_message_send webhook` failed or not. Field is only accessible in push webhook
         /// </summary>
         public bool? BeforeMessageSendFailed { get; set; }
+
+        /// <summary>
+        /// Channel object
+        /// </summary>
+        public Channel Channel { get; set; }
 
         /// <summary>
         /// Channel unique identifier in &lt;type&gt;:&lt;id&gt; format
@@ -166,9 +172,9 @@ namespace StreamChat.Core.Models
 
         Message ILoadableFrom<MessageDTO, Message>.LoadFromDto(MessageDTO dto)
         {
-            AdditionalProperties = dto.AdditionalProperties;
             Attachments = Attachments.TryLoadFromDtoCollection(dto.Attachments);
             BeforeMessageSendFailed = dto.BeforeMessageSendFailed;
+            //Channel?
             Cid = dto.Cid;
             Command = dto.Command;
             CreatedAt = dto.CreatedAt;
@@ -186,7 +192,7 @@ namespace StreamChat.Core.Models
             Pinned = dto.Pinned;
             PinnedAt = dto.PinnedAt;
             PinnedBy = PinnedBy.TryLoadFromDto<UserObjectDTO, User>(dto.PinnedBy);
-            QuotedMessage = QuotedMessage.TryLoadFromDto(dto.QuotedMessage);
+            QuotedMessage = QuotedMessage.TryLoadFromDto<MessageDTO, Message>(dto.QuotedMessage);
             QuotedMessageId = dto.QuotedMessageId;
             ReactionCounts = dto.ReactionCounts;
             ReactionScores = dto.ReactionScores;
@@ -199,6 +205,47 @@ namespace StreamChat.Core.Models
             Type = dto.Type;
             UpdatedAt = dto.UpdatedAt;
             User = User.TryLoadFromDto<UserObjectDTO, User>(dto.User);
+            AdditionalProperties = dto.AdditionalProperties;
+
+            return this;
+        }
+
+        Message ILoadableFrom<SearchResultMessageDTO, Message>.LoadFromDto(SearchResultMessageDTO dto)
+        {
+            Attachments = Attachments.TryLoadFromDtoCollection(dto.Attachments);
+            BeforeMessageSendFailed = dto.BeforeMessageSendFailed;
+            Channel = Channel.TryLoadFromDto(dto.Channel);
+            Cid = dto.Cid;
+            Command = dto.Command;
+            CreatedAt = dto.CreatedAt;
+            DeletedAt = dto.DeletedAt;
+            Html = dto.Html;
+            I18n = dto.I18n;
+            Id = dto.Id;
+            ImageLabels = dto.ImageLabels;
+            LatestReactions = LatestReactions.TryLoadFromDtoCollection(dto.LatestReactions);
+            MentionedUsers = MentionedUsers.TryLoadFromDtoCollection(dto.MentionedUsers);
+            Mml = dto.Mml;
+            OwnReactions = OwnReactions.TryLoadFromDtoCollection(dto.OwnReactions);
+            ParentId = dto.ParentId;
+            PinExpires = dto.PinExpires;
+            Pinned = dto.Pinned;
+            PinnedAt = dto.PinnedAt;
+            PinnedBy = PinnedBy.TryLoadFromDto<UserObjectDTO, User>(dto.PinnedBy);
+            QuotedMessage = QuotedMessage.TryLoadFromDto<MessageDTO, Message>(dto.QuotedMessage);
+            QuotedMessageId = dto.QuotedMessageId;
+            ReactionCounts = dto.ReactionCounts;
+            ReactionScores = dto.ReactionScores;
+            ReplyCount = dto.ReplyCount;
+            Shadowed = dto.Shadowed;
+            ShowInChannel = dto.ShowInChannel;
+            Silent = dto.Silent;
+            Text = dto.Text;
+            ThreadParticipants = ThreadParticipants.TryLoadFromDtoCollection(dto.ThreadParticipants);
+            Type = dto.Type;
+            UpdatedAt = dto.UpdatedAt;
+            User = User.TryLoadFromDto<UserObjectDTO, User>(dto.User);
+            AdditionalProperties = dto.AdditionalProperties;
 
             return this;
         }

--- a/Assets/Plugins/StreamChat/Core/Models/MessageFlag.cs
+++ b/Assets/Plugins/StreamChat/Core/Models/MessageFlag.cs
@@ -30,7 +30,7 @@ namespace StreamChat.Core.Models
             ApprovedAt = dto.ApprovedAt;
             CreatedAt = dto.CreatedAt;
             CreatedByAutomod = dto.CreatedByAutomod;
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             ModerationResult = ModerationResult.TryLoadFromDto(dto.ModerationResult);
             RejectedAt = dto.RejectedAt;
             ReviewedAt = dto.ReviewedAt;

--- a/Assets/Plugins/StreamChat/Core/Requests/SearchRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/Requests/SearchRequest.cs
@@ -1,0 +1,58 @@
+﻿using StreamChat.Core.DTO.Models;
+using StreamChat.Core.DTO.Requests;
+using StreamChat.Core.Helpers;
+using StreamChat.Core.Models;
+
+namespace StreamChat.Core.Requests
+{
+    public partial class SearchRequest : RequestObjectBase, ISavableTo<SearchRequestDTO>
+    {
+        /// <summary>
+        /// Channel filter conditions
+        /// </summary>
+        public System.Collections.Generic.Dictionary<string, object> FilterConditions { get; set; } = new System.Collections.Generic.Dictionary<string, object>();
+
+        /// <summary>
+        /// Number of messages to return
+        /// </summary>
+        public double? Limit { get; set; }
+
+        /// <summary>
+        /// Message filter conditions
+        /// </summary>
+        public System.Collections.Generic.Dictionary<string, object> MessageFilterConditions { get; set; }
+
+        /// <summary>
+        /// Pagination parameter. Cannot be used with non-zero offset.
+        /// </summary>
+        public string Next { get; set; }
+
+        /// <summary>
+        /// Pagination offset. Cannot be used with sort or next.
+        /// </summary>
+        public double? Offset { get; set; }
+
+        /// <summary>
+        /// Search phrase
+        /// </summary>
+        public string Query { get; set; }
+
+        /// <summary>
+        /// Sort parameters. Cannot be used with non-zero offset
+        /// </summary>
+        public System.Collections.Generic.List<SortParam> Sort { get; set; }
+
+        SearchRequestDTO ISavableTo<SearchRequestDTO>.SaveToDto() =>
+            new SearchRequestDTO
+            {
+                FilterConditions = FilterConditions,
+                Limit = Limit,
+                MessageFilterConditions = MessageFilterConditions,
+                Next = Next,
+                Offset = Offset,
+                Query = Query,
+                Sort = Sort.TrySaveToDtoCollection<SortParam, SortParamDTO>(),
+                AdditionalProperties = AdditionalProperties,
+            };
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Requests/SearchRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/Requests/SearchRequest.cs
@@ -15,7 +15,7 @@ namespace StreamChat.Core.Requests
         /// <summary>
         /// Number of messages to return
         /// </summary>
-        public double? Limit { get; set; }
+        public int? Limit { get; set; }
 
         /// <summary>
         /// Message filter conditions
@@ -30,7 +30,7 @@ namespace StreamChat.Core.Requests
         /// <summary>
         /// Pagination offset. Cannot be used with sort or next.
         /// </summary>
-        public double? Offset { get; set; }
+        public int? Offset { get; set; }
 
         /// <summary>
         /// Search phrase

--- a/Assets/Plugins/StreamChat/Core/Requests/SearchRequest.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Requests/SearchRequest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c62049ada0d745e2a4fd6a3828346aea
+timeCreated: 1660840177

--- a/Assets/Plugins/StreamChat/Core/Responses/Event.cs
+++ b/Assets/Plugins/StreamChat/Core/Responses/Event.cs
@@ -91,7 +91,7 @@ namespace StreamChat.Core.Responses
             CreatedBy = CreatedBy.TryLoadFromDto<UserObjectDTO, User>(dto.CreatedBy);
             Me = Me.TryLoadFromDto<OwnUserDTO, OwnUser>(dto.Me);
             Member = Member.TryLoadFromDto(dto.Member);
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             ParentId = dto.ParentId;
             Reaction = Reaction.TryLoadFromDto(dto.Reaction);
             Reason = dto.Reason;

--- a/Assets/Plugins/StreamChat/Core/Responses/MessageResponse.cs
+++ b/Assets/Plugins/StreamChat/Core/Responses/MessageResponse.cs
@@ -1,4 +1,5 @@
-﻿using StreamChat.Core.DTO.Responses;
+﻿using StreamChat.Core.DTO.Models;
+using StreamChat.Core.DTO.Responses;
 using StreamChat.Core.Helpers;
 using StreamChat.Core.Models;
 
@@ -16,7 +17,7 @@ namespace StreamChat.Core.Responses
         MessageResponse ILoadableFrom<MessageResponseDTO, MessageResponse>.LoadFromDto(MessageResponseDTO dto)
         {
             Duration = dto.Duration;
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             AdditionalProperties = dto.AdditionalProperties;
 
             return this;

--- a/Assets/Plugins/StreamChat/Core/Responses/ReactionRemovalResponse.cs
+++ b/Assets/Plugins/StreamChat/Core/Responses/ReactionRemovalResponse.cs
@@ -1,4 +1,5 @@
-﻿using StreamChat.Core.DTO.Responses;
+﻿using StreamChat.Core.DTO.Models;
+using StreamChat.Core.DTO.Responses;
 using StreamChat.Core.Helpers;
 using StreamChat.Core.Models;
 
@@ -18,7 +19,7 @@ namespace StreamChat.Core.Responses
         ReactionRemovalResponse ILoadableFrom<ReactionRemovalResponseDTO, ReactionRemovalResponse>.LoadFromDto(ReactionRemovalResponseDTO dto)
         {
             Duration = Duration;
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             Reaction = Reaction.TryLoadFromDto(dto.Reaction);
             AdditionalProperties = AdditionalProperties;
 

--- a/Assets/Plugins/StreamChat/Core/Responses/ReactionResponse.cs
+++ b/Assets/Plugins/StreamChat/Core/Responses/ReactionResponse.cs
@@ -1,4 +1,5 @@
-﻿using StreamChat.Core.DTO.Responses;
+﻿using StreamChat.Core.DTO.Models;
+using StreamChat.Core.DTO.Responses;
 using StreamChat.Core.Helpers;
 using StreamChat.Core.Models;
 
@@ -18,7 +19,7 @@ namespace StreamChat.Core.Responses
         ReactionResponse ILoadableFrom<ReactionResponseDTO, ReactionResponse>.LoadFromDto(ReactionResponseDTO dto)
         {
             Duration = dto.Duration;
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             Reaction = Reaction.TryLoadFromDto(dto.Reaction);
             AdditionalProperties = dto.AdditionalProperties;
 

--- a/Assets/Plugins/StreamChat/Core/Responses/SearchResponse.cs
+++ b/Assets/Plugins/StreamChat/Core/Responses/SearchResponse.cs
@@ -1,0 +1,46 @@
+﻿using StreamChat.Core.DTO.Responses;
+using StreamChat.Core.Helpers;
+using StreamChat.Core.Responses;
+
+namespace StreamChat.Core.Responses
+{
+    public partial class SearchResponse : ResponseObjectBase, ILoadableFrom<SearchResponseDTO, SearchResponse>
+    {
+        /// <summary>
+        /// Duration of the request in human-readable format
+        /// </summary>
+        public string Duration { get; set; }
+
+        /// <summary>
+        /// Value to pass to the next search query in order to paginate
+        /// </summary>
+        public string Next { get; set; }
+
+        /// <summary>
+        /// Value that points to the previous page. Pass as the next value in a search query to paginate backwards
+        /// </summary>
+        public string Previous { get; set; }
+
+        /// <summary>
+        /// Search results
+        /// </summary>
+        public System.Collections.Generic.List<SearchResult> Results { get; set; }
+
+        /// <summary>
+        /// Warning about the search results
+        /// </summary>
+        public SearchWarning ResultsWarning { get; set; }
+
+        SearchResponse ILoadableFrom<SearchResponseDTO, SearchResponse>.LoadFromDto(SearchResponseDTO dto)
+        {
+            Duration = dto.Duration;
+            Next = dto.Next;
+            Previous = dto.Previous;
+            Results = Results.TryLoadFromDtoCollection(dto.Results);
+            ResultsWarning = ResultsWarning.TryLoadFromDto(dto.ResultsWarning);
+            AdditionalProperties = dto.AdditionalProperties;
+
+            return this;
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Responses/SearchResponse.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Responses/SearchResponse.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1b174fa462d0441391fbda80a11e30a2
+timeCreated: 1660858763

--- a/Assets/Plugins/StreamChat/Core/Responses/SearchResult.cs
+++ b/Assets/Plugins/StreamChat/Core/Responses/SearchResult.cs
@@ -1,0 +1,23 @@
+﻿using StreamChat.Core.DTO.Responses;
+using StreamChat.Core.Helpers;
+using StreamChat.Core.Models;
+using StreamChat.Core.Responses;
+
+namespace StreamChat.Core.Responses
+{
+    public partial class SearchResult : ResponseObjectBase, ILoadableFrom<SearchResultDTO, SearchResult>
+    {
+        /// <summary>
+        /// Found message
+        /// </summary>
+        public Message Message { get; set; }
+
+        SearchResult ILoadableFrom<SearchResultDTO, SearchResult>.LoadFromDto(SearchResultDTO dto)
+        {
+            Message = Message.TryLoadFromDto<SearchResultMessageDTO, Message>(dto.Message);
+            AdditionalProperties = dto.AdditionalProperties;
+
+            return this;
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Responses/SearchResult.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Responses/SearchResult.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3d3c923f11c7441b97572bd433a403e3
+timeCreated: 1660858763

--- a/Assets/Plugins/StreamChat/Core/Responses/SearchWarning.cs
+++ b/Assets/Plugins/StreamChat/Core/Responses/SearchWarning.cs
@@ -1,0 +1,39 @@
+﻿using StreamChat.Core.DTO.Models;
+using StreamChat.Core.Responses;
+
+namespace StreamChat.Core.Responses
+{
+    public partial class SearchWarning : ResponseObjectBase, ILoadableFrom<SearchWarningDTO, SearchWarning>
+    {
+        /// <summary>
+        /// Channel CIDs for the searched channels
+        /// </summary>
+        public System.Collections.Generic.List<string> ChannelSearchCids { get; set; }
+
+        /// <summary>
+        /// Number of channels searched
+        /// </summary>
+        public double? ChannelSearchCount { get; set; }
+
+        /// <summary>
+        /// Code corresponding to the warning
+        /// </summary>
+        public double? WarningCode { get; set; }
+
+        /// <summary>
+        /// Description of the warning
+        /// </summary>
+        public string WarningDescription { get; set; }
+
+        SearchWarning ILoadableFrom<SearchWarningDTO, SearchWarning>.LoadFromDto(SearchWarningDTO dto)
+        {
+            ChannelSearchCids = dto.ChannelSearchCids;
+            ChannelSearchCount = dto.ChannelSearchCount;
+            WarningCode = dto.WarningCode;
+            WarningDescription = dto.WarningDescription;
+            AdditionalProperties = dto.AdditionalProperties;
+
+            return this;
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Responses/SearchWarning.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Responses/SearchWarning.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cbd9be165db0436aad48b387317f2fdd
+timeCreated: 1660858763

--- a/Assets/Plugins/StreamChat/Core/Responses/TruncateChannelResponse.cs
+++ b/Assets/Plugins/StreamChat/Core/Responses/TruncateChannelResponse.cs
@@ -1,4 +1,5 @@
-﻿using StreamChat.Core.DTO.Responses;
+﻿using StreamChat.Core.DTO.Models;
+using StreamChat.Core.DTO.Responses;
 using StreamChat.Core.Helpers;
 using StreamChat.Core.Models;
 
@@ -19,7 +20,7 @@ namespace StreamChat.Core.Responses
         {
             Channel = Channel.TryLoadFromDto(dto.Channel);
             Duration = dto.Duration;
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             AdditionalProperties = dto.AdditionalProperties;
 
             return this;

--- a/Assets/Plugins/StreamChat/Core/Responses/UpdateChannelResponse.cs
+++ b/Assets/Plugins/StreamChat/Core/Responses/UpdateChannelResponse.cs
@@ -1,4 +1,5 @@
-﻿using StreamChat.Core.DTO.Responses;
+﻿using StreamChat.Core.DTO.Models;
+using StreamChat.Core.DTO.Responses;
 using StreamChat.Core.Helpers;
 using StreamChat.Core.Models;
 
@@ -22,7 +23,7 @@ namespace StreamChat.Core.Responses
             Channel = Channel.TryLoadFromDto(dto.Channel);
             Duration = dto.Duration;
             Members = Members.TryLoadFromDtoCollection(dto.Members);
-            Message = Message.TryLoadFromDto(dto.Message);
+            Message = Message.TryLoadFromDto<MessageDTO, Message>(dto.Message);
             AdditionalProperties = dto.AdditionalProperties;
 
             return this;

--- a/Assets/Plugins/StreamChat/SampleProject/Scripts/Views/ChannelHeaderView.cs
+++ b/Assets/Plugins/StreamChat/SampleProject/Scripts/Views/ChannelHeaderView.cs
@@ -61,7 +61,7 @@ namespace StreamChat.SampleProject.Views
         {
             if (!_channelCidToTypingUserIds.TryGetValue(obj.Cid, out var userIds))
             {
-                _channelCidToTypingUserIds[obj.Cid] = new HashSet<string>();
+                _channelCidToTypingUserIds[obj.Cid] = userIds = new HashSet<string>();
             }
 
             userIds.Add(obj.User.Id);

--- a/Assets/Plugins/StreamChat/Samples/ClientDocs/MessagesApiCodeSamples.cs
+++ b/Assets/Plugins/StreamChat/Samples/ClientDocs/MessagesApiCodeSamples.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading.Tasks;
 using StreamChat.Core;
 using StreamChat.Core.Requests;
+using UnityEngine;
 
 namespace Plugins.StreamChat.Samples.ClientDocs
 {
@@ -162,6 +163,35 @@ namespace Plugins.StreamChat.Samples.ClientDocs
 
             var deleteFileResponse = await Client.MessageApi.DeleteFileAsync(channelType: "messaging",
                 channelId: "channel-id-1", remoteFileUrl);
+        }
+
+        public async Task SearchMessages()
+        {
+            var searchResponse = await Client.MessageApi.SearchMessagesAsync(new SearchRequest
+            {
+                //Filter is required for search
+                FilterConditions = new Dictionary<string, object>
+                {
+                    {
+                        //Get channels that local user is a member of
+                        "members", new Dictionary<string, object>
+                        {
+                            { "$in", new[] { "John" } }
+                        }
+                    }
+                },
+
+                //search phrase
+                Query = "supercalifragilisticexpialidocious"
+            });
+
+            foreach (var searchResult in searchResponse.Results)
+            {
+                Debug.Log(searchResult.Message.Id); //Message ID
+                Debug.Log(searchResult.Message.Text); //Message text
+                Debug.Log(searchResult.Message.User); //Message author info
+                Debug.Log(searchResult.Message.Channel); //Channel info
+            }
         }
 
         private IStreamChatClient Client;

--- a/Assets/Plugins/StreamChat/Tests/Integration/BaseIntegrationTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/Integration/BaseIntegrationTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using NUnit.Framework;
 using StreamChat.Core;
@@ -16,6 +17,7 @@ using StreamChat.Libs.Serialization;
 using StreamChat.Libs.Utils;
 using UnityEditor;
 using UnityEngine;
+using Random = UnityEngine.Random;
 
 namespace StreamChat.Tests.Integration
 {
@@ -108,8 +110,32 @@ namespace StreamChat.Tests.Integration
             }
         }
 
+        protected string GenerateRandomMessage(int minWords = 2, int maxWords = 10, int minWordLength = 2, int maxWordLength = 8)
+        {
+            var wordsCount = Random.Range(minWords, maxWords);
+            while (wordsCount-- > 0)
+            {
+                var wordLength = Random.Range(minWordLength, maxWordLength);
+
+                while (wordLength-- > 0)
+                {
+                    _sb.Append(Random.Range(0, WordChars.Length));
+                }
+
+                _sb.Append(" ");
+            }
+
+            var result = _sb.ToString();
+            _sb.Clear();
+            return result;
+        }
+
+        const string WordChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
         private readonly List<(string ChannelType, string ChannelId)> _tempChannelsToDelete =
             new List<(string ChannelType, string ChannelId)>();
+        private StringBuilder _sb = new StringBuilder();
+
 
         private void DeleteTempChannels()
         {


### PR DESCRIPTION
### Summary:
Allows to searcht through history messages for a given phrase.

### How to use:
- Use `Client.MessageApi.SearchMessagesAsync` 
- In `SearchRequest` body provide: `FilterConditions` & `Query` (phrase to search)