### PR TITLE
Add utility method to allow running Task as callback

### DIFF
--- a/Assets/Plugins/StreamChat/Core/Helpers/TaskExt.cs
+++ b/Assets/Plugins/StreamChat/Core/Helpers/TaskExt.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace StreamChat.Core.Helpers
+{
+    /// <summary>
+    /// Extensions for Task
+    /// </summary>
+    public static class TaskExt
+    {
+        /// <summary>
+        /// Run task as callback
+        /// </summary>
+        /// <param name="onSuccess">Called when task succeeds. Contains response object</param>
+        /// <param name="onFailure">Called when task fails. Contains thrown exception.</param>
+        /// <typeparam name="TResponse">Type of response when task succeeds.</typeparam>
+        public static void AsCallback<TResponse>(this Task<TResponse> task, Action<TResponse> onSuccess = null, Action<Exception> onFailure = null)
+        {
+            task.ContinueWith(_ =>
+            {
+                if (_.IsFaulted)
+                {
+                    onFailure?.Invoke(_.Exception);
+                    return;
+                }
+
+                onSuccess?.Invoke(_.Result);
+            });
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Helpers/TaskExt.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Helpers/TaskExt.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 995b77fbb95b48f9bd2e6593fb96e537
+timeCreated: 1662559695


### PR DESCRIPTION
This utility method allows to turn any Task asynchronous method into a classical callback:
```
Client.ChannelApi.QueryChannelsAsync(queryChannelsRequest)
    .AsCallback(onSuccess: response =>
    {
        foreach (var channelState in response.Channels)
        {
            //channelState contains channel data
        }
    }, onFailure: exception =>
    {
        //React to failed request
        Debug.LogException(exception);
    });
```