### PR TITLE
Fix health check monitoring unit test

### DIFF
--- a/Assets/Plugins/StreamChat/Tests/StreamChatClientTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StreamChatClientTests.cs
@@ -142,6 +142,11 @@ namespace StreamChat.Tests
                 return Task.CompletedTask;
             });
 
+            _mockWebsocketClient.When(_ => _.Disconnect()).Do(callbackInfo =>
+            {
+                _mockWebsocketClient.Disconnected += Raise.Event<Action>();
+            });
+
             _mockWebsocketClient.TryDequeueMessage(out Arg.Any<string>()).Returns(arg =>
             {
                 arg[0] = "{\"connection_id\":\"fakeId\", \"type\":\"health.check\"}";


### PR DESCRIPTION
Fix Disconnected event not being triggered when mocking WS Client disconnection in unit test