### PR TITLE
Mark `EventNotificationMarkRead.UnreadCount` and `StreamChatClient.LocalUser` as deprecated

### DIFF
--- a/Assets/Plugins/StreamChat/Core/Events/EventNotificationMarkRead.cs
+++ b/Assets/Plugins/StreamChat/Core/Events/EventNotificationMarkRead.cs
@@ -1,6 +1,6 @@
-﻿using StreamChat.Core.DTO.Events;
+﻿using System;
+using StreamChat.Core.DTO.Events;
 using StreamChat.Core.DTO.Models;
-using StreamChat.Core.Events;
 using StreamChat.Core.Helpers;
 using StreamChat.Core.Models;
 
@@ -30,6 +30,7 @@ namespace StreamChat.Core.Events
 
         public int? UnreadChannels { get; set; }
 
+        [Obsolete("Please use the TotalUnreadCount. This property will be removed in the future.")]
         public int? UnreadCount { get; set; }
 
         public User User { get; set; }
@@ -45,7 +46,9 @@ namespace StreamChat.Core.Events
             TotalUnreadCount = dto.TotalUnreadCount;
             Type = dto.Type;
             UnreadChannels = dto.UnreadChannels;
-            UnreadCount = dto.UnreadCount;
+#pragma warning disable 0618
+            UnreadCount = dto.TotalUnreadCount;
+#pragma warning restore 0618
             User = User.TryLoadFromDto<UserObjectDTO, User>(dto.User);
             AdditionalProperties = dto.AdditionalProperties;
 

--- a/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
@@ -60,7 +60,8 @@ namespace StreamChat.Core
         public IModerationApi ModerationApi { get; }
         public IUserApi UserApi { get; }
 
-        //Todo Remove
+        [Obsolete("This property presents only initial state of the LocalUser when connection is made and is not being updated any further. " +
+                  "Please use the OwnUser object returned via StreamChatClient.Connected event. This property will  be removed in the future.")]
         public OwnUser LocalUser { get; private set; }
 
         public ConnectionState ConnectionState
@@ -351,13 +352,15 @@ namespace StreamChat.Core
         private void OnConnectionConfirmed(EventHealthCheck healthCheckEvent)
         {
             _connectionId = healthCheckEvent.ConnectionId;
+#pragma warning disable 0618
             LocalUser = healthCheckEvent.Me;
+#pragma warning restore 0618
             _lastHealthCheckReceivedTime = _timeService.Time;
             _reconnectAttempt = 0;
             ConnectionState = ConnectionState.Connected;
 
             _logs.Info("Connection confirmed by server with connection id: " + _connectionId);
-            Connected?.Invoke(LocalUser);
+            Connected?.Invoke(healthCheckEvent.Me);
         }
 
         private void TryToReconnect()


### PR DESCRIPTION
- mark `EventNotificationMarkRead.UnreadCount` deprecated - it duplicates the `TotalUnreadCount`
- mark `StreamChatClient.LocalUser` deprecated - it is not updated after the connection