### PR TITLE
Fix WebSocket token cancellation and resources cleanup 

### DIFF
--- a/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.WebSockets;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -60,8 +61,9 @@ namespace StreamChat.Core
         public IModerationApi ModerationApi { get; }
         public IUserApi UserApi { get; }
 
-        [Obsolete("This property presents only initial state of the LocalUser when connection is made and is not being updated any further. " +
-                  "Please use the OwnUser object returned via StreamChatClient.Connected event. This property will  be removed in the future.")]
+        [Obsolete(
+            "This property presents only initial state of the LocalUser when connection is made and is not being updated any further. " +
+            "Please use the OwnUser object returned via StreamChatClient.Connected event. This property will  be removed in the future.")]
         public OwnUser LocalUser { get; private set; }
 
         public ConnectionState ConnectionState
@@ -97,7 +99,8 @@ namespace StreamChat.Core
         /// Use this method to create the main client instance or use StreamChatClient constructor to create a client instance with custom dependencies
         /// </summary>
         /// <param name="authCredentials">Authorization data with ApiKey, UserToken and UserId</param>
-        public static IStreamChatClient CreateDefaultClient(AuthCredentials authCredentials, IStreamClientConfig config = default)
+        public static IStreamChatClient CreateDefaultClient(AuthCredentials authCredentials,
+            IStreamClientConfig config = default)
         {
             config ??= StreamClientConfig.Default;
             var logs = LibsFactory.CreateDefaultLogs(config.LogLevel.ToLogLevel());
@@ -219,11 +222,9 @@ namespace StreamChat.Core
             }
         }
 
-        public bool IsLocalUser(User user)
-            => user.Id == _authCredentials.UserId;
+        public bool IsLocalUser(User user) => user.Id == _authCredentials.UserId;
 
-        public bool IsLocalUser(ChannelMember channelMember)
-            => channelMember.User.Id == _authCredentials.UserId;
+        public bool IsLocalUser(ChannelMember channelMember) => channelMember.User.Id == _authCredentials.UserId;
 
         public void SetReconnectStrategySettings(ReconnectStrategy reconnectStrategy, float? exponentialMinInterval,
             float? exponentialMaxInterval, float? constantInterval)
@@ -276,7 +277,7 @@ namespace StreamChat.Core
 
         internal IInternalChannelApi InternalChannelApi { get; }
         internal IInternalMessageApi InternalMessageApi { get; }
-        internal IInternalModerationApi InternalModerationApi { get;}
+        internal IInternalModerationApi InternalModerationApi { get; }
         internal InternalUserApi InternalUserApi { get; }
 
         private const string DefaultStreamAuthType = "jwt";
@@ -524,6 +525,7 @@ namespace StreamChat.Core
                 {
                     _logs.Warning($"No message handler registered for `{type}`. Message not handled: " + msg);
                 }
+
                 return;
             }
 
@@ -547,7 +549,10 @@ namespace StreamChat.Core
             if (timeSinceLastHealthCheck > HealthCheckMaxWaitingTime)
             {
                 _logs.Warning($"Health check was not received since: {timeSinceLastHealthCheck}, reset connection");
-                _websocketClient.Disconnect();
+                _websocketClient
+                    .DisconnectAsync(WebSocketCloseStatus.InternalServerError,
+                        $"Health check was not received since: {timeSinceLastHealthCheck}")
+                    .ContinueWith(_ => _logs.Exception(_.Exception), TaskContinuationOptions.OnlyOnFaulted);
             }
         }
 
@@ -578,8 +583,8 @@ namespace StreamChat.Core
             return r.IsMatch(userId);
         }
 
-        private static string Base64UrlEncode(byte[] input) =>
-            Convert.ToBase64String(input)
+        private static string Base64UrlEncode(byte[] input)
+            => Convert.ToBase64String(input)
                 .Replace('+', '-')
                 .Replace('/', '_')
                 .Trim('=');

--- a/Assets/Plugins/StreamChat/Libs/Websockets/IWebsocketClient.cs
+++ b/Assets/Plugins/StreamChat/Libs/Websockets/IWebsocketClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.WebSockets;
 using System.Threading.Tasks;
 
 namespace StreamChat.Libs.Websockets
@@ -20,6 +21,6 @@ namespace StreamChat.Libs.Websockets
 
         void Send(string message);
 
-        void Disconnect();
+        void Disconnect(WebSocketCloseStatus closeStatus, string closeMessage);
     }
 }

--- a/Assets/Plugins/StreamChat/Libs/Websockets/IWebsocketClient.cs
+++ b/Assets/Plugins/StreamChat/Libs/Websockets/IWebsocketClient.cs
@@ -21,6 +21,6 @@ namespace StreamChat.Libs.Websockets
 
         void Send(string message);
 
-        void Disconnect(WebSocketCloseStatus closeStatus, string closeMessage);
+        Task DisconnectAsync(WebSocketCloseStatus closeStatus, string closeMessage);
     }
 }

--- a/Assets/Plugins/StreamChat/Libs/Websockets/WebsocketClient.cs
+++ b/Assets/Plugins/StreamChat/Libs/Websockets/WebsocketClient.cs
@@ -238,22 +238,26 @@ namespace StreamChat.Libs.Websockets
                 LogExceptionIfDebugMode(e);
             }
 
+            if (_internalClient == null)
+            {
+                return;
+            }
+
             try
             {
-                if (_internalClient != null)
+                if (!_clientClosedStates.Contains(_internalClient.State))
                 {
-                    if (!_clientClosedStates.Contains(_internalClient.State))
-                    {
-                        await _internalClient.CloseOutputAsync(closeStatus, closeMessage, CancellationToken.None);
-                    }
-
-                    _internalClient.Dispose();
-                    _internalClient = null;
+                    await _internalClient.CloseOutputAsync(closeStatus, closeMessage, CancellationToken.None);
                 }
             }
             catch (Exception e)
             {
                 LogExceptionIfDebugMode(e);
+            }
+            finally
+            {
+                _internalClient.Dispose();
+                _internalClient = null;
             }
         }
 

--- a/Assets/Plugins/StreamChat/Libs/Websockets/WebsocketClient.cs
+++ b/Assets/Plugins/StreamChat/Libs/Websockets/WebsocketClient.cs
@@ -224,22 +224,36 @@ namespace StreamChat.Libs.Websockets
 
         private async Task TryDisposeResourcesAsync(WebSocketCloseStatus closeStatus, string closeMessage)
         {
-            if (_connectionCts != null)
+            try
             {
-                _connectionCts.Cancel();
-                _connectionCts.Dispose();
-                _connectionCts = null;
+                if (_connectionCts != null)
+                {
+                    _connectionCts.Cancel();
+                    _connectionCts.Dispose();
+                    _connectionCts = null;
+                }
+            }
+            catch (Exception e)
+            {
+                LogExceptionIfDebugMode(e);
             }
 
-            if (_internalClient != null)
+            try
             {
-                if (!_clientClosedStates.Contains(_internalClient.State))
+                if (_internalClient != null)
                 {
-                    await _internalClient.CloseOutputAsync(closeStatus, closeMessage, CancellationToken.None);
-                }
+                    if (!_clientClosedStates.Contains(_internalClient.State))
+                    {
+                        await _internalClient.CloseOutputAsync(closeStatus, closeMessage, CancellationToken.None);
+                    }
 
-                _internalClient.Dispose();
-                _internalClient = null;
+                    _internalClient.Dispose();
+                    _internalClient = null;
+                }
+            }
+            catch (Exception e)
+            {
+                LogExceptionIfDebugMode(e);
             }
         }
 

--- a/Assets/Plugins/StreamChat/Libs/Websockets/WebsocketClient.cs
+++ b/Assets/Plugins/StreamChat/Libs/Websockets/WebsocketClient.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
+using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
@@ -35,8 +36,7 @@ namespace StreamChat.Libs.Websockets
             _bufferSegment = new ArraySegment<byte>(readBuffer);
         }
 
-        public bool TryDequeueMessage(out string message)
-            => _receiveQueue.TryDequeue(out message);
+        public bool TryDequeueMessage(out string message) => _receiveQueue.TryDequeue(out message);
 
         public async Task ConnectAsync(Uri serverUri)
         {
@@ -48,7 +48,7 @@ namespace StreamChat.Libs.Websockets
 
             _uri = serverUri ?? throw new ArgumentNullException(nameof(serverUri));
 
-            _connectionCts?.Dispose();
+            TryDisposeResources(WebSocketCloseStatus.NormalClosure, "Cleaning up resources before connecting");
             _connectionCts = new CancellationTokenSource();
 
             try
@@ -56,12 +56,19 @@ namespace StreamChat.Libs.Websockets
                 _internalClient = new ClientWebSocket();
                 await _internalClient.ConnectAsync(_uri, _connectionCts.Token).ConfigureAwait(false);
             }
+            catch (OperationCanceledException e)
+            {
+                LogExceptionIfDebugMode(e);
+            }
             catch (WebSocketException e)
             {
-                if (_isDebugMode)
-                {
-                    _logs.Exception(e);
-                }
+                LogExceptionIfDebugMode(e);
+                OnConnectionFailed();
+                return;
+            }
+            catch (SocketException e)
+            {
+                LogExceptionIfDebugMode(e);
                 OnConnectionFailed();
                 return;
             }
@@ -89,52 +96,46 @@ namespace StreamChat.Libs.Websockets
 
             _sendQueue.Add(messageSegment);
         }
+
         public void Update()
         {
             var disconnect = false;
             while (_threadWebsocketExceptionsLog.TryDequeue(out var webSocketException))
             {
-                if (_isDebugMode)
-                {
-                    _logs.Exception(webSocketException);
-                }
+                LogExceptionIfDebugMode(webSocketException);
 
                 disconnect = true;
             }
 
             if (disconnect)
             {
-                Disconnect();
+                Disconnect(WebSocketCloseStatus.ProtocolError, "WebSocket thrown an exception");
                 return;
             }
 
             while (_threadExceptionsLog.TryDequeue(out var exception))
             {
-                _logs.Exception(exception);
+                LogExceptionIfDebugMode(exception);
             }
         }
 
-        public void Disconnect()
+        public void Disconnect(WebSocketCloseStatus closeStatus, string closeMessage)
         {
-            _logs.Info("Disconnect");
-            _connectionCts?.Dispose();
-
-            if (_internalClient != null && !_clientClosedStates.Contains(_internalClient.State))
-            {
-                _internalClient?.CloseOutputAsync(WebSocketCloseStatus.Empty, statusDescription: null, CancellationToken.None);
-                _internalClient?.Dispose();
-                _internalClient = null;
-            }
+            LogInfoIfDebugMode("Disconnect");
+            TryDisposeResources(closeStatus, closeMessage);
 
             Disconnected?.Invoke();
         }
 
         public void Dispose()
-            => Disconnect();
+        {
+            LogInfoIfDebugMode("Dispose");
+            Disconnect(WebSocketCloseStatus.NormalClosure, "WebSocket client is disposed");
+        }
 
         private static Encoding DefaultEncoding { get; } = Encoding.UTF8;
 
-        private readonly WebSocketState[] _clientClosedStates = new[]
+        private static readonly WebSocketState[] _clientClosedStates = new[]
             { WebSocketState.Closed, WebSocketState.CloseSent, WebSocketState.CloseReceived, WebSocketState.Aborted };
 
         private readonly ConcurrentQueue<string> _receiveQueue = new ConcurrentQueue<string>();
@@ -160,13 +161,15 @@ namespace StreamChat.Libs.Websockets
         {
             while (IsConnected && !_connectionCts.IsCancellationRequested)
             {
-                while (!_sendQueue.IsCompleted)
+                while (_sendQueue.TryTake(out var msg))
                 {
-                    var msg = _sendQueue.Take();
-
                     try
                     {
-                        await _internalClient.SendAsync(msg, WebSocketMessageType.Text, true, CancellationToken.None);
+                        await _internalClient.SendAsync(msg, WebSocketMessageType.Text, true, _connectionCts.Token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return;
                     }
                     catch (WebSocketException webSocketException)
                     {
@@ -178,6 +181,8 @@ namespace StreamChat.Libs.Websockets
                         _threadExceptionsLog.Enqueue(e);
                     }
                 }
+
+                await Task.Delay(1);
             }
         }
 
@@ -194,6 +199,10 @@ namespace StreamChat.Libs.Websockets
                         continue;
                     }
                 }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
                 catch (WebSocketException webSocketException)
                 {
                     _threadWebsocketExceptionsLog.Enqueue(webSocketException);
@@ -204,14 +213,37 @@ namespace StreamChat.Libs.Websockets
                     _threadExceptionsLog.Enqueue(e);
                 }
 
-                Task.Delay(50).Wait();
+                await Task.Delay(1);
             }
         }
 
-        private void OnConnectionFailed()
-            => ConnectionFailed?.Invoke();
+        private void TryDisposeResources(WebSocketCloseStatus closeStatus, string closeMessage)
+        {
+            try
+            {
+                _connectionCts?.Cancel();
+                _connectionCts?.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
 
-        private void OnReceivedCloseMessage() => Disconnect();
+            if (_internalClient != null)
+            {
+                if (!_clientClosedStates.Contains(_internalClient.State))
+                {
+                    _internalClient.CloseOutputAsync(closeStatus, closeMessage, CancellationToken.None);
+                }
+
+                _internalClient.Dispose();
+                _internalClient = null;
+            }
+        }
+
+        private void OnConnectionFailed() => ConnectionFailed?.Invoke();
+
+        private void OnReceivedCloseMessage()
+            => Disconnect(WebSocketCloseStatus.InternalServerError, "Server closed the connection");
 
         private async Task<string> TryReceiveSingleMessageAsync()
         {
@@ -237,6 +269,8 @@ namespace StreamChat.Libs.Websockets
                     ms.Write(_bufferSegment.Array, _bufferSegment.Offset, chunkResult.Count);
                 } while (!chunkResult.EndOfMessage && !_connectionCts.IsCancellationRequested);
 
+                _connectionCts.Token.ThrowIfCancellationRequested();
+
                 //reset position before reading from stream
                 ms.Seek(0, SeekOrigin.Begin);
 
@@ -254,6 +288,22 @@ namespace StreamChat.Libs.Websockets
                 }
 
                 return "";
+            }
+        }
+
+        private void LogExceptionIfDebugMode(Exception exception)
+        {
+            if (_isDebugMode)
+            {
+                _logs.Exception(exception);
+            }
+        }
+
+        private void LogInfoIfDebugMode(string info)
+        {
+            if (_isDebugMode)
+            {
+                _logs.Info(info);
             }
         }
     }

--- a/Assets/Plugins/StreamChat/Tests/StreamChatClientTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StreamChatClientTests.cs
@@ -1,5 +1,6 @@
 ﻿#if STREAM_TESTS_ENABLED
 using System;
+using System.Net.WebSockets;
 using System.Threading.Tasks;
 using NSubstitute;
 using NUnit.Framework;
@@ -152,10 +153,8 @@ namespace StreamChat.Tests
                 return Task.CompletedTask;
             });
 
-            _mockWebsocketClient.When(_ => _.Disconnect()).Do(callbackInfo =>
-            {
-                _mockWebsocketClient.Disconnected += Raise.Event<Action>();
-            });
+            _mockWebsocketClient.When(_ => _.DisconnectAsync(Arg.Any<WebSocketCloseStatus>(), Arg.Any<string>()))
+                .Do(callbackInfo => { _mockWebsocketClient.Disconnected += Raise.Event<Action>(); });
 
             _mockWebsocketClient.TryDequeueMessage(out Arg.Any<string>()).Returns(arg =>
             {


### PR DESCRIPTION
- Fix token not being canceled before disposing
- Ensure resources are cleanup up before reconnection
- Pass token to `_internalClient.SendAsync`