### PR TITLE
Add support for push devices endpoint

### DIFF
--- a/Assets/Plugins/StreamChat/Core/API/DeviceApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/DeviceApi.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading.Tasks;
+using StreamChat.Core.API.Internal;
+using StreamChat.Core.Helpers;
+using StreamChat.Core.InternalDTO.Responses;
+using StreamChat.Core.Requests;
+using StreamChat.Core.Responses;
+
+namespace StreamChat.Core.API
+{
+    internal class DeviceApi : IDeviceApi
+    {
+        public DeviceApi(IInternalDeviceApi internalDeviceApi)
+        {
+            _internalDeviceApi = internalDeviceApi ?? throw new ArgumentNullException(nameof(internalDeviceApi));
+        }
+
+        public async Task<ApiResponse> AddDeviceAsync(CreateDeviceRequest device)
+        {
+            var dto = await _internalDeviceApi.AddDeviceAsync(device.TrySaveToDto());
+            return dto.ToDomain<ResponseInternalDTO, ApiResponse>();
+        }
+
+        public async Task<ListDevicesResponse> ListDevicesAsync(string userId)
+        {
+            var dto = await _internalDeviceApi.ListDevicesAsync(userId);
+            return dto.ToDomain<ListDevicesResponseInternalDTO, ListDevicesResponse>();
+        }
+
+
+        public async Task<ApiResponse> RemoveDeviceAsync(string deviceId, string userId)
+        {
+            var dto = await _internalDeviceApi.RemoveDeviceAsync(deviceId, userId);
+            return dto.ToDomain<ResponseInternalDTO, ApiResponse>();
+        }
+
+        private readonly IInternalDeviceApi _internalDeviceApi;
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/API/DeviceApi.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/API/DeviceApi.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8045b9ba16a7443b848087fe2eeea809
+timeCreated: 1667316690

--- a/Assets/Plugins/StreamChat/Core/API/IDeviceApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/IDeviceApi.cs
@@ -4,12 +4,31 @@ using StreamChat.Core.Responses;
         
 namespace StreamChat.Core.API
 {
+    /// <summary>
+    /// API Client that can be used to retrieve, create and alter push notification devices of a Stream Chat application.
+    /// </summary>
+    /// <remarks>https://getstream.io/chat/docs/unity/push_devices/?language=unity</remarks>
     public interface IDeviceApi
     {
+        /// <summary>
+        /// <para>Adds a new device.</para>
+        /// Registering a device associates it with a user and tells the
+        /// push provider to send new message notifications to the device.
+        /// </summary>
+        /// <remarks>https://getstream.io/chat/docs/unity/push_devices/?language=unity</remarks>
         Task<ApiResponse> AddDeviceAsync(CreateDeviceRequest device);
 
+        /// <summary>
+        /// Provides a list of all devices associated with a user.
+        /// </summary>
+        /// <remarks>https://getstream.io/chat/docs/unity/push_devices/?language=unity</remarks>
         Task<ListDevicesResponse> ListDevicesAsync(string userId);
 
+        /// <summary>
+        /// <para>Removes a device.</para>
+        /// Unregistering a device removes the device from the user and stops further new message notifications.
+        /// </summary>
+        /// <remarks>https://getstream.io/chat/docs/unity/push_devices/?language=unity</remarks>
         Task<ApiResponse> RemoveDeviceAsync(string deviceId, string userId);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/API/IDeviceApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/IDeviceApi.cs
@@ -1,10 +1,10 @@
 ﻿using System.Threading.Tasks;
 using StreamChat.Core.Requests;
 using StreamChat.Core.Responses;
-
+        
 namespace StreamChat.Core.API
 {
-    internal interface IDeviceApi
+    public interface IDeviceApi
     {
         Task<ApiResponse> AddDeviceAsync(CreateDeviceRequest device);
 

--- a/Assets/Plugins/StreamChat/Core/API/IDeviceApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/IDeviceApi.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using StreamChat.Core.Requests;
+using StreamChat.Core.Responses;
+
+namespace StreamChat.Core.API
+{
+    internal interface IDeviceApi
+    {
+        Task<ApiResponse> AddDeviceAsync(CreateDeviceRequest device);
+
+        Task<ListDevicesResponse> ListDevicesAsync(string userId);
+
+        Task<ApiResponse> RemoveDeviceAsync(string deviceId, string userId);
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/API/IDeviceApi.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/API/IDeviceApi.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2e5934386c2f49dd97ba0cb8fb2985a3
+timeCreated: 1667316690

--- a/Assets/Plugins/StreamChat/Core/API/Internal/IInternalDeviceApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/Internal/IInternalDeviceApi.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using StreamChat.Core.InternalDTO.Requests;
+using StreamChat.Core.InternalDTO.Responses;
+
+namespace StreamChat.Core.API.Internal
+{
+    internal interface IInternalDeviceApi
+    {
+        Task<ResponseInternalDTO> AddDeviceAsync(CreateDeviceRequestInternalDTO device);
+
+        Task<ListDevicesResponseInternalDTO> ListDevicesAsync(string userId);
+
+        Task<ResponseInternalDTO> RemoveDeviceAsync(string deviceId, string userId);
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/API/Internal/IInternalDeviceApi.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/API/Internal/IInternalDeviceApi.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c492d1a153cb49edb45749af9429bcb7
+timeCreated: 1667315377

--- a/Assets/Plugins/StreamChat/Core/API/Internal/InternalApiClientBase.cs
+++ b/Assets/Plugins/StreamChat/Core/API/Internal/InternalApiClientBase.cs
@@ -60,6 +60,35 @@ namespace StreamChat.Core.API.Internal
             }
         }
 
+        protected async Task<TResponse> Get<TResponse>(string endpoint, Dictionary<string, string> parameters = null)
+        {
+            var uri = _requestUriFactory.CreateEndpointUri(endpoint, parameters);
+
+            var httpResponse = await _httpClient.GetAsync(uri);
+            var responseContent = await httpResponse.Content.ReadAsStringAsync();
+
+            if (!httpResponse.IsSuccessStatusCode)
+            {
+                LogRestCall(uri, endpoint, HttpMethod.Get, responseContent, success: false);
+
+                var apiError = _serializer.Deserialize<APIErrorInternalDTO>(responseContent);
+                throw new StreamApiException(apiError);
+            }
+
+            try
+            {
+                var response = _serializer.Deserialize<TResponse>(responseContent);
+                LogRestCall(uri, endpoint, HttpMethod.Get, responseContent, success: true);
+
+                return response;
+            }
+            catch (Exception e)
+            {
+                LogRestCall(uri, endpoint, HttpMethod.Get, responseContent, success: false);
+                throw new StreamDeserializationException(responseContent, typeof(TResponse), e);
+            }
+        }
+
         protected async Task<TResponse> Post<TRequest, TResponse>(string endpoint, TRequest request)
         {
             var uri = _requestUriFactory.CreateEndpointUri(endpoint);

--- a/Assets/Plugins/StreamChat/Core/API/Internal/InternalDeviceApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/Internal/InternalDeviceApi.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading.Tasks;
+using StreamChat.Core.InternalDTO.Requests;
+using StreamChat.Core.InternalDTO.Responses;
+using StreamChat.Core.Web;
+using StreamChat.Libs.Http;
+using StreamChat.Libs.Logs;
+using StreamChat.Libs.Serialization;
+
+namespace StreamChat.Core.API.Internal
+{
+    internal class InternalDeviceApi : InternalApiClientBase, IInternalDeviceApi
+    {
+        public InternalDeviceApi(IHttpClient httpClient, ISerializer serializer, ILogs logs,
+            IRequestUriFactory requestUriFactory)
+            : base(httpClient, serializer, logs, requestUriFactory)
+        {
+        }
+
+        public Task<ResponseInternalDTO> AddDeviceAsync(CreateDeviceRequestInternalDTO device)
+            => Post<CreateDeviceRequestInternalDTO, ResponseInternalDTO>("devices", device);
+
+        public Task<ListDevicesResponseInternalDTO> ListDevicesAsync(string userId)
+        {
+            var parameters = QueryParameters.Default.Append("user_id", userId);
+            return Get<ListDevicesResponseInternalDTO>("devices", parameters);
+        }
+
+        public Task<ResponseInternalDTO> RemoveDeviceAsync(string deviceId, string userId)
+        {
+            var parameters = QueryParameters.Default
+                .Append("id", deviceId)
+                .Append("user_id", userId);
+
+            return Delete<ResponseInternalDTO>("devices", parameters);
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/API/Internal/InternalDeviceApi.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/API/Internal/InternalDeviceApi.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 197fc7109cb44ecbac16eb0e311380bf
+timeCreated: 1667315377

--- a/Assets/Plugins/StreamChat/Core/API/Internal/InternalUserApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/Internal/InternalUserApi.cs
@@ -22,10 +22,13 @@ namespace StreamChat.Core.API.Internal
         public Task<GuestResponseInternalDTO> CreateGuestAsync(GuestRequestInternalDTO createGuestRequest)
             => Post<GuestRequestInternalDTO, GuestResponseInternalDTO>("/guest", createGuestRequest);
 
-        public Task<UpdateUsersResponseInternalDTO> UpsertManyUsersAsync(UpdateUsersRequestInternalDTO updateUsersRequest)
+        public Task<UpdateUsersResponseInternalDTO>
+            UpsertManyUsersAsync(UpdateUsersRequestInternalDTO updateUsersRequest)
             => Post<UpdateUsersRequestInternalDTO, UpdateUsersResponseInternalDTO>("/users", updateUsersRequest);
 
-        public Task<UpdateUsersResponseInternalDTO> UpdateUserPartialAsync(UpdateUserPartialRequestInternalDTO updateUserPartialRequest)
-            => Patch<UpdateUserPartialRequestInternalDTO, UpdateUsersResponseInternalDTO>("/users", updateUserPartialRequest);
+        public Task<UpdateUsersResponseInternalDTO>
+            UpdateUserPartialAsync(UpdateUserPartialRequestInternalDTO updateUserPartialRequest)
+            => Patch<UpdateUserPartialRequestInternalDTO, UpdateUsersResponseInternalDTO>("/users",
+                updateUserPartialRequest);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/IStreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/IStreamChatClient.cs
@@ -37,6 +37,7 @@ namespace StreamChat.Core
         IMessageApi MessageApi { get; }
         IModerationApi ModerationApi { get; }
         IUserApi UserApi { get; }
+        IDeviceApi DeviceApi { get; }
 
         [Obsolete(
             "This property presents only initial state of the LocalUser when connection is made and is not being updated any further. " +

--- a/Assets/Plugins/StreamChat/Core/Requests/CreateDeviceRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/Requests/CreateDeviceRequest.cs
@@ -1,0 +1,23 @@
+﻿using StreamChat.Core.InternalDTO.Models;
+using StreamChat.Core.InternalDTO.Requests;
+using StreamChat.Core.Requests;
+
+namespace StreamChat.Core.Requests
+{
+    public partial class CreateDeviceRequest : RequestObjectBase, ISavableTo<CreateDeviceRequestInternalDTO>
+    {
+        public string Id { get; set; }
+
+        public PushProviderType? PushProvider { get; set; }
+
+        public string PushProviderName { get; set; }
+
+        CreateDeviceRequestInternalDTO ISavableTo<CreateDeviceRequestInternalDTO>.SaveToDto()
+            => new CreateDeviceRequestInternalDTO
+            {
+                Id = Id,
+                PushProvider = PushProvider,
+                PushProviderName = PushProviderName,
+            };
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Requests/CreateDeviceRequest.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Requests/CreateDeviceRequest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3bbd71968cbf4f29a1482c5b359b76f9
+timeCreated: 1667316371

--- a/Assets/Plugins/StreamChat/Core/Responses/ListDevicesResponse.cs
+++ b/Assets/Plugins/StreamChat/Core/Responses/ListDevicesResponse.cs
@@ -1,0 +1,28 @@
+﻿using StreamChat.Core.Helpers;
+using StreamChat.Core.InternalDTO.Responses;
+using StreamChat.Core.Models;
+
+namespace StreamChat.Core.Responses
+{
+    public partial class ListDevicesResponse : ResponseObjectBase, ILoadableFrom<ListDevicesResponseInternalDTO, ListDevicesResponse>
+    {
+        /// <summary>
+        /// List of devices
+        /// </summary>
+        public System.Collections.Generic.List<Device> Devices { get; set; }
+
+        /// <summary>
+        /// Duration of the request in human-readable format
+        /// </summary>
+        public string Duration { get; set; }
+
+        ListDevicesResponse ILoadableFrom<ListDevicesResponseInternalDTO, ListDevicesResponse>.LoadFromDto(ListDevicesResponseInternalDTO dto)
+        {
+            Devices = Devices.TryLoadFromDtoCollection(dto.Devices);
+            Duration = dto.Duration;
+            AdditionalProperties = dto.AdditionalProperties;
+
+            return this;
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Responses/ListDevicesResponse.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Responses/ListDevicesResponse.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a133b8fb95954a6789f44c53cf2f74c4
+timeCreated: 1667316465

--- a/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
@@ -146,6 +146,7 @@ namespace StreamChat.Core
         public IMessageApi MessageApi { get; }
         public IModerationApi ModerationApi { get; }
         public IUserApi UserApi { get; }
+        public IDeviceApi DeviceApi { get; }
 
         [Obsolete(
             "This property presents only initial state of the LocalUser when connection is made and is not ever updated. " +
@@ -261,11 +262,13 @@ namespace StreamChat.Core
             InternalMessageApi = new InternalMessageApi(httpClient, serializer, logs, _requestUriFactory);
             InternalModerationApi = new InternalModerationApi(httpClient, serializer, logs, _requestUriFactory);
             InternalUserApi = new InternalUserApi(httpClient, serializer, logs, _requestUriFactory);
+            InternalDeviceApi = new InternalDeviceApi(httpClient, serializer, logs, _requestUriFactory);
 
             ChannelApi = new ChannelApi(InternalChannelApi);
             MessageApi = new MessageApi(InternalMessageApi);
             ModerationApi = new ModerationApi(InternalModerationApi);
             UserApi = new UserApi(InternalUserApi);
+            DeviceApi = new DeviceApi(InternalDeviceApi);
 
             RegisterEventHandlers();
 
@@ -365,7 +368,8 @@ namespace StreamChat.Core
         internal IInternalChannelApi InternalChannelApi { get; }
         internal IInternalMessageApi InternalMessageApi { get; }
         internal IInternalModerationApi InternalModerationApi { get; }
-        internal InternalUserApi InternalUserApi { get; }
+        internal IInternalUserApi InternalUserApi { get; }
+        internal IInternalDeviceApi InternalDeviceApi { get; }
 
         private const string DefaultStreamAuthType = "jwt";
         private const int HealthCheckMaxWaitingTime = 30;

--- a/Assets/Plugins/StreamChat/Samples/ClientDocs/DeviceApiCodeSamples.cs
+++ b/Assets/Plugins/StreamChat/Samples/ClientDocs/DeviceApiCodeSamples.cs
@@ -23,8 +23,8 @@ namespace Plugins.StreamChat.Samples.ClientDocs
 
         public async Task ListDevicesAsync()
         {
-            var listDevicesResponse = await Client.DeviceApi.ListDevicesAsync(Client.UserId);
-            foreach (var userDevice in listDevicesResponse.Devices)
+            var response = await Client.DeviceApi.ListDevicesAsync(Client.UserId);
+            foreach (var userDevice in response.Devices)
             {
                 Debug.Log(userDevice.Id); // Unique Device ID provided by push notifications provider
                 Debug.Log(userDevice.CreatedAt);

--- a/Assets/Plugins/StreamChat/Samples/ClientDocs/DeviceApiCodeSamples.cs
+++ b/Assets/Plugins/StreamChat/Samples/ClientDocs/DeviceApiCodeSamples.cs
@@ -1,0 +1,45 @@
+using System.Threading.Tasks;
+using StreamChat.Core;
+using StreamChat.Core.InternalDTO.Models;
+using StreamChat.Core.Requests;
+using UnityEngine;
+
+namespace Plugins.StreamChat.Samples.ClientDocs
+{
+    /// <summary>
+    /// Code samples for Channels sections: https://getstream.io/chat/docs/unity/push_devices/?language=unity
+    /// </summary>
+    internal class DeviceApiCodeSamples
+    {
+        public async Task AddDeviceAsync()
+        {
+            await Client.DeviceApi.AddDeviceAsync(new CreateDeviceRequest
+            {
+                //Device ID provided by the notifications provider e.g. Token provided by Firebase Messaging SDK
+                Id = "unique-device-id", 
+                PushProvider = PushProviderType.Firebase,
+            });
+        }
+
+        public async Task ListDevicesAsync()
+        {
+            var listDevicesResponse = await Client.DeviceApi.ListDevicesAsync(Client.UserId);
+            foreach (var userDevice in listDevicesResponse.Devices)
+            {
+                Debug.Log(userDevice.Id); // Unique Device ID provided by push notifications provider
+                Debug.Log(userDevice.CreatedAt);
+                Debug.Log(userDevice.PushProvider); //E.g. Firebase
+                Debug.Log(userDevice.Disabled);
+                Debug.Log(userDevice.DisabledReason);
+            }
+        }
+
+        public async Task RemoveDeviceAsync()
+        {
+            var deviceId = "unique-device-id";
+            await Client.DeviceApi.RemoveDeviceAsync(deviceId, Client.UserId);
+        }
+        
+        private IStreamChatClient Client;
+    }
+}

--- a/Assets/Plugins/StreamChat/Samples/ClientDocs/DeviceApiCodeSamples.cs.meta
+++ b/Assets/Plugins/StreamChat/Samples/ClientDocs/DeviceApiCodeSamples.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8d36df7ef6f9415597c44bb60192d417
+timeCreated: 1667584991

--- a/Assets/Plugins/StreamChat/Tests/Integration/DeviceApiIntegrationTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/Integration/DeviceApiIntegrationTests.cs
@@ -1,0 +1,51 @@
+#if STREAM_TESTS_ENABLED
+using System.Collections;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using StreamChat.Core.InternalDTO.Models;
+using StreamChat.Core.Requests;
+using UnityEngine.TestTools;
+
+namespace StreamChat.Tests.Integration
+{
+    /// <summary>
+    /// Integration tests for Users
+    /// </summary>
+    public class DeviceApiIntegrationTests : BaseIntegrationTests
+    {
+        [UnityTest]
+        public IEnumerator Test_complete_device_cycle_add_list_remove()
+        {
+            yield return Client.WaitForClientToConnect();
+            yield return Test_complete_device_cycle_add_list_remove_Async().RunTaskAsEnumerator(Client);
+        }
+
+        private async Task Test_complete_device_cycle_add_list_remove_Async()
+        {
+            const string NewDeviceId = "aaaa-bbb-ccc-111-2222-333";
+            
+            //Add device, expect no errors
+            await Client.DeviceApi.AddDeviceAsync(new CreateDeviceRequest
+            {
+                Id = NewDeviceId,
+                PushProvider = PushProviderType.Firebase,
+            });
+
+            //List devices, expect newly added device returned
+            var listDevices = await Client.DeviceApi.ListDevicesAsync(Client.UserId);
+            Assert.NotNull(listDevices.Devices);
+            var addedDevice = listDevices.Devices.FirstOrDefault(d => d.Id == NewDeviceId);
+            Assert.NotNull(addedDevice);
+            Assert.AreEqual(PushProviderType.Firebase, addedDevice.PushProvider);
+            
+            //Remove devices, expect no errors
+            await Client.DeviceApi.RemoveDeviceAsync(NewDeviceId, Client.UserId);
+            
+            //Expect device list empty
+            listDevices = await Client.DeviceApi.ListDevicesAsync(Client.UserId);
+            Assert.That(listDevices.Devices, Is.Null.Or.Empty);
+        }
+    }
+}
+#endif

--- a/Assets/Plugins/StreamChat/Tests/Integration/DeviceApiIntegrationTests.cs.meta
+++ b/Assets/Plugins/StreamChat/Tests/Integration/DeviceApiIntegrationTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dfdc466bfd17449b88ad62856e534437
+timeCreated: 1667582548

--- a/Assets/Plugins/StreamChat/Tests/UnityTestUtils.cs
+++ b/Assets/Plugins/StreamChat/Tests/UnityTestUtils.cs
@@ -107,6 +107,28 @@ namespace StreamChat.Tests
             }
         }
 
+        public static IEnumerator RunTaskAsEnumerator(this Task task, IStreamChatClient client)
+        {
+            while (!task.IsCompleted)
+            {
+                client.Update(0.1f);
+                yield return null;
+            }
+            
+            if (!task.IsFaulted)
+            {
+                yield break;
+            }
+            
+            if (task.Exception is AggregateException aggregateException &&
+                aggregateException.InnerExceptions.Count == 1)
+            {
+                throw task.Exception.InnerException;
+            }
+
+            throw task.Exception;
+        }
+
         public static IEnumerator WaitForSeconds(float seconds)
         {
             var timeStarted = Time.realtimeSinceStartup;


### PR DESCRIPTION
Add support for `DeviceApi`:
- Adding user's device that will receive push notifications (if a push provider is configured in Stream Dashboard)
```
await Client.DeviceApi.AddDeviceAsync(new CreateDeviceRequest
{
    //Device ID provided by the notifications provider e.g. Token provided by Firebase Messaging SDK
    Id = "unique-device-id", 
    PushProvider = PushProviderType.Firebase,
});
```
- Listing user's devices
```
var response = await Client.DeviceApi.ListDevicesAsync(Client.UserId);
foreach (var userDevice in response.Devices)
{
    Debug.Log(userDevice.Id); // Unique Device ID provided by push notifications provider
    Debug.Log(userDevice.CreatedAt);
    Debug.Log(userDevice.PushProvider); //E.g. Firebase
    Debug.Log(userDevice.Disabled);
    Debug.Log(userDevice.DisabledReason);
}
```
- Removing Device
```
var deviceId = "unique-device-id";
await Client.DeviceApi.RemoveDeviceAsync(deviceId, Client.UserId);
```

Read more in the [push devices docs](https://getstream.io/chat/docs/unity/push_devices/?language=unity)