### PR TITLE
Feature/implement token provider with auto refresh on expiry

### DIFF
--- a/Assets/Plugins/StreamChat/Core/API/Internal/InternalDeviceApi.cs
+++ b/Assets/Plugins/StreamChat/Core/API/Internal/InternalDeviceApi.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using StreamChat.Core.InternalDTO.Requests;
 using StreamChat.Core.InternalDTO.Responses;
+using StreamChat.Core.LowLevelClient;
 using StreamChat.Core.LowLevelClient.API.Internal;
 using StreamChat.Core.Web;
 using StreamChat.Libs.Http;
@@ -12,8 +13,8 @@ namespace StreamChat.Core.API.Internal
     internal class InternalDeviceApi : InternalApiClientBase, IInternalDeviceApi
     {
         public InternalDeviceApi(IHttpClient httpClient, ISerializer serializer, ILogs logs,
-            IRequestUriFactory requestUriFactory)
-            : base(httpClient, serializer, logs, requestUriFactory)
+            IRequestUriFactory requestUriFactory, IStreamChatLowLevelClient lowLevelClient)
+            : base(httpClient, serializer, logs, requestUriFactory, lowLevelClient)
         {
         }
 

--- a/Assets/Plugins/StreamChat/Core/Exceptions/StreamApiException.cs
+++ b/Assets/Plugins/StreamChat/Core/Exceptions/StreamApiException.cs
@@ -10,8 +10,8 @@ namespace StreamChat.Core.Exceptions
     /// </summary>
     public class StreamApiException : Exception
     {
-        public double? StatusCode { get; }
-        public double? Code { get;  }
+        public int? StatusCode { get; }
+        public int? Code { get;  }
         public string Duration { get;  }
         public string ErrorMessage { get;  }
         public string MoreInfo { get;  }

--- a/Assets/Plugins/StreamChat/Core/Exceptions/StreamMissingAuthCredentialsException.cs
+++ b/Assets/Plugins/StreamChat/Core/Exceptions/StreamMissingAuthCredentialsException.cs
@@ -10,7 +10,6 @@ namespace StreamChat.Core.Exceptions
         public StreamMissingAuthCredentialsException(string message)
             : base(message)
         {
-
         }
     }
 }

--- a/Assets/Plugins/StreamChat/Core/Exceptions/TokenProviderException.cs
+++ b/Assets/Plugins/StreamChat/Core/Exceptions/TokenProviderException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using StreamChat.Libs.Auth;
+
+namespace StreamChat.Core.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when the injected <see cref="ITokenProvider"/> fails to return a token
+    /// </summary>
+    public class TokenProviderException : Exception
+    {
+        public TokenProviderException(string message)
+            : base(message)
+        {
+        }
+        
+        public TokenProviderException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/Exceptions/TokenProviderException.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/Exceptions/TokenProviderException.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f2d97f5de917451995fec845a46fe73f
+timeCreated: 1671103910

--- a/Assets/Plugins/StreamChat/Core/IStreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/IStreamChatClient.cs
@@ -50,6 +50,11 @@ namespace StreamChat.Core
         /// Is client connected. Subscribe to <see cref="Connected"/> to get notified when connection is established
         /// </summary>
         bool IsConnected { get; }
+        
+        /// <summary>
+        /// If true it means that client initiated connection and is waiting for the Stream server to confirm the connection. Subscribe to <see cref="Connected"/> to get notified when connection is established
+        /// </summary>
+        bool IsConnecting { get; }
 
         /// <summary>
         /// Data of the user that is connected to the Stream Chat using the local device. This property is set after the client connection is established.
@@ -91,11 +96,22 @@ namespace StreamChat.Core
         /// Connect user to Stream Chat server.
         /// </summary>
         /// <param name="apiKey">Your application API KEY. You can get it from https://dashboard.getstream.io/</param>
-        /// <param name="userId">User ID.</param>
+        /// <param name="userId">ID of a user that will be connected to the Stream Chat</param>
         /// <param name="userAuthToken">User authentication token.</param>
         /// <param name="cancellationToken">Cancellation token that will abort the login request when cancelled</param>
         /// <remarks>https://getstream.io/chat/docs/unity/unity_client_overview/?language=unity#auth-credentials</remarks>
         Task<IStreamLocalUserData> ConnectUserAsync(string apiKey, string userId, string userAuthToken,
+            CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="apiKey">Your application API KEY. You can get it from https://dashboard.getstream.io/</param>
+        /// <param name="userId">ID of a user that will be connected to the Stream Chat</param>
+        /// <param name="tokenProvider">Service that will provide authorization token for a given user id. Use <see cref="TokenProvider"/></param>
+        /// <param name="cancellationToken">Cancellation token that will abort the login request when cancelled</param>
+        /// <returns></returns>
+        Task<IStreamLocalUserData> ConnectUserAsync(string apiKey, string userId, ITokenProvider tokenProvider,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -182,6 +198,5 @@ namespace StreamChat.Core
         Task DisconnectUserAsync();
         
         bool IsLocalUser(IStreamUser messageUser);
-
     }
 }

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/API/Internal/InternalApiClientBase.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/API/Internal/InternalApiClientBase.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -20,249 +19,35 @@ namespace StreamChat.Core.LowLevelClient.API.Internal
     internal abstract class InternalApiClientBase
     {
         protected InternalApiClientBase(IHttpClient httpClient, ISerializer serializer, ILogs logs,
-            IRequestUriFactory requestUriFactory)
+            IRequestUriFactory requestUriFactory, IStreamChatLowLevelClient lowLevelClient)
         {
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
             _logs = logs ?? throw new ArgumentNullException(nameof(logs));
             _requestUriFactory = requestUriFactory ?? throw new ArgumentNullException(nameof(requestUriFactory));
+            _lowLevelClient = lowLevelClient ?? throw new ArgumentNullException(nameof(lowLevelClient));
         }
 
-        protected async Task<TResponse> Get<TPayload, TResponse>(string endpoint, TPayload payload)
-        {
-            var payloadContent = _serializer.Serialize(payload);
-            var parameters = QueryParameters.Default.Append("payload", payloadContent);
+        protected Task<TResponse> Get<TPayload, TResponse>(string endpoint, TPayload payload)
+            => HttpRequest<TResponse>(HttpMethod.Get, endpoint, payload);
 
-            var uri = _requestUriFactory.CreateEndpointUri(endpoint, parameters);
+        protected Task<TResponse> Get<TResponse>(string endpoint, QueryParameters parameters = null)
+            => HttpRequest<TResponse>(HttpMethod.Get, endpoint, queryParameters: parameters);
 
-            var httpResponse = await _httpClient.GetAsync(uri);
-            var responseContent = await httpResponse.Content.ReadAsStringAsync();
+        protected Task<TResponse> Post<TRequest, TResponse>(string endpoint, TRequest request)
+            => HttpRequest<TResponse>(HttpMethod.Post, endpoint, request);
 
-            if (!httpResponse.IsSuccessStatusCode)
-            {
-                LogRestCall(uri, endpoint, HttpMethod.Get, responseContent, success: false);
+        protected Task<TResponse> Post<TResponse>(string endpoint, HttpContent request)
+            => HttpRequest<TResponse>(HttpMethod.Post, endpoint, request);
 
-                var apiError = _serializer.Deserialize<APIErrorInternalDTO>(responseContent);
-                throw new StreamApiException(apiError);
-            }
+        protected Task<TResponse> Put<TRequest, TResponse>(string endpoint, TRequest request)
+            => HttpRequest<TResponse>(HttpMethod.Put, endpoint, request);
 
-            try
-            {
-                var response = _serializer.Deserialize<TResponse>(responseContent);
-                LogRestCall(uri, endpoint, HttpMethod.Get, responseContent, success: true);
+        protected Task<TResponse> Patch<TRequest, TResponse>(string endpoint, TRequest request)
+            => HttpRequest<TResponse>(PatchHttpMethod, endpoint, request);
 
-                return response;
-            }
-            catch (Exception e)
-            {
-                LogRestCall(uri, endpoint, HttpMethod.Get, responseContent, success: false);
-                throw new StreamDeserializationException(responseContent, typeof(TResponse), e);
-            }
-        }
-
-        protected async Task<TResponse> Get<TResponse>(string endpoint, Dictionary<string, string> parameters = null)
-        {
-            var uri = _requestUriFactory.CreateEndpointUri(endpoint, parameters);
-
-            var httpResponse = await _httpClient.GetAsync(uri);
-            var responseContent = await httpResponse.Content.ReadAsStringAsync();
-
-            if (!httpResponse.IsSuccessStatusCode)
-            {
-                LogRestCall(uri, endpoint, HttpMethod.Get, responseContent, success: false);
-
-                var apiError = _serializer.Deserialize<APIErrorInternalDTO>(responseContent);
-                throw new StreamApiException(apiError);
-            }
-
-            try
-            {
-                var response = _serializer.Deserialize<TResponse>(responseContent);
-                LogRestCall(uri, endpoint, HttpMethod.Get, responseContent, success: true);
-
-                return response;
-            }
-            catch (Exception e)
-            {
-                LogRestCall(uri, endpoint, HttpMethod.Get, responseContent, success: false);
-                throw new StreamDeserializationException(responseContent, typeof(TResponse), e);
-            }
-        }
-
-        protected async Task<TResponse> Post<TRequest, TResponse>(string endpoint, TRequest request)
-        {
-            var uri = _requestUriFactory.CreateEndpointUri(endpoint);
-            var requestContent = _serializer.Serialize(request);
-
-            HttpResponseMessage httpResponse;
-            try
-            {
-                httpResponse = await _httpClient.PostAsync(uri, requestContent);
-            }
-            catch (Exception e)
-            {
-                _logs.Exception(e);
-                throw;
-            }
-
-            var responseContent = await httpResponse.Content.ReadAsStringAsync();
-
-            if (!httpResponse.IsSuccessStatusCode)
-            {
-                LogRestCall(uri, endpoint, HttpMethod.Post, responseContent, success: false, requestContent);
-
-                var apiError = _serializer.Deserialize<APIErrorInternalDTO>(responseContent);
-                throw new StreamApiException(apiError);
-            }
-
-            try
-            {
-                var response = _serializer.Deserialize<TResponse>(responseContent);
-                LogRestCall(uri, endpoint, HttpMethod.Post, responseContent, success: true, requestContent);
-
-                return response;
-            }
-            catch (Exception e)
-            {
-                LogRestCall(uri, endpoint, HttpMethod.Post, responseContent, success: false, requestContent);
-                throw new StreamDeserializationException(responseContent, typeof(TResponse), e);
-            }
-        }
-
-        protected async Task<TResponse> Post<TResponse>(string endpoint, HttpContent request)
-        {
-            var uri = _requestUriFactory.CreateEndpointUri(endpoint);
-
-            HttpResponseMessage httpResponse;
-            try
-            {
-                httpResponse = await _httpClient.PostAsync(uri, request);
-            }
-            catch (Exception e)
-            {
-                _logs.Exception(e);
-                throw;
-            }
-
-            var responseContent = await httpResponse.Content.ReadAsStringAsync();
-
-            if (!httpResponse.IsSuccessStatusCode)
-            {
-                LogRestCall(uri, endpoint, HttpMethod.Post, responseContent, success: false, request.ToString());
-
-                var apiError = _serializer.Deserialize<APIErrorInternalDTO>(responseContent);
-                throw new StreamApiException(apiError);
-            }
-
-            try
-            {
-                var response = _serializer.Deserialize<TResponse>(responseContent);
-                LogRestCall(uri, endpoint, HttpMethod.Post, responseContent, success: true, request.ToString());
-                return response;
-            }
-            catch (Exception e)
-            {
-                LogRestCall(uri, endpoint, HttpMethod.Post, responseContent, success: false, request.ToString());
-                throw new StreamDeserializationException(responseContent, typeof(TResponse), e);
-            }
-        }
-
-        protected async Task<TResponse> Put<TRequest, TResponse>(string endpoint, TRequest request)
-        {
-            var uri = _requestUriFactory.CreateEndpointUri(endpoint);
-            var requestContent = _serializer.Serialize(request);
-
-            HttpResponseMessage httpResponse;
-            try
-            {
-                httpResponse = await _httpClient.PutAsync(uri, requestContent);
-            }
-            catch (Exception e)
-            {
-                _logs.Exception(e);
-                throw;
-            }
-
-            var responseContent = await httpResponse.Content.ReadAsStringAsync();
-
-            if (!httpResponse.IsSuccessStatusCode)
-            {
-                LogRestCall(uri, endpoint, HttpMethod.Put, responseContent, success: false, requestContent);
-
-                var apiError = _serializer.Deserialize<APIErrorInternalDTO>(responseContent);
-                throw new StreamApiException(apiError);
-            }
-
-            try
-            {
-                var response = _serializer.Deserialize<TResponse>(responseContent);
-                LogRestCall(uri, endpoint, HttpMethod.Put, responseContent, success: true, requestContent);
-
-                return response;
-            }
-            catch (Exception e)
-            {
-                LogRestCall(uri, endpoint, HttpMethod.Put, responseContent, success: false, requestContent);
-                throw new StreamDeserializationException(responseContent, typeof(TResponse), e);
-            }
-        }
-
-        protected async Task<TResponse> Patch<TRequest, TResponse>(string endpoint, TRequest request)
-        {
-            var uri = _requestUriFactory.CreateEndpointUri(endpoint);
-            var requestContent = _serializer.Serialize(request);
-
-            var httpResponse = await _httpClient.PatchAsync(uri, requestContent);
-            var responseContent = await httpResponse.Content.ReadAsStringAsync();
-
-            if (!httpResponse.IsSuccessStatusCode)
-            {
-                LogRestCall(uri, endpoint, new HttpMethod("PATCH"), responseContent, success: false, requestContent);
-
-                var apiError = _serializer.Deserialize<APIErrorInternalDTO>(responseContent);
-                throw new StreamApiException(apiError);
-            }
-
-            try
-            {
-                var response = _serializer.Deserialize<TResponse>(responseContent);
-                LogRestCall(uri, endpoint, new HttpMethod("PATCH"), responseContent, success: true, requestContent);
-                return response;
-            }
-            catch (Exception e)
-            {
-                LogRestCall(uri, endpoint, new HttpMethod("PATCH"), responseContent, success: false, requestContent);
-                throw new StreamDeserializationException(responseContent, typeof(TResponse), e);
-            }
-        }
-
-        protected async Task<TResponse> Delete<TResponse>(string endpoint, Dictionary<string, string> parameters = null)
-        {
-            var uri = _requestUriFactory.CreateEndpointUri(endpoint, parameters);
-
-            var httpResponse = await _httpClient.DeleteAsync(uri);
-            var responseContent = await httpResponse.Content.ReadAsStringAsync();
-
-            if (!httpResponse.IsSuccessStatusCode)
-            {
-                LogRestCall(uri, endpoint, HttpMethod.Delete, responseContent, success: false);
-
-                var apiError = _serializer.Deserialize<APIErrorInternalDTO>(responseContent);
-                throw new StreamApiException(apiError);
-            }
-
-            try
-            {
-                var response = _serializer.Deserialize<TResponse>(responseContent);
-                LogRestCall(uri, endpoint, HttpMethod.Delete, responseContent, success: true);
-                return response;
-            }
-            catch (Exception e)
-            {
-                LogRestCall(uri, endpoint, HttpMethod.Delete, responseContent, success: false);
-                throw new StreamDeserializationException(responseContent, typeof(TResponse), e);
-            }
-        }
+        protected Task<TResponse> Delete<TResponse>(string endpoint, QueryParameters parameters = null)
+            => HttpRequest<TResponse>(HttpMethod.Delete, endpoint, queryParameters: parameters);
 
         protected Task PostEventAsync(string channelType, string channelId, object eventBodyDto)
             => Post<SendEventRequestInternalDTO, ResponseInternalDTO>(
@@ -271,13 +56,183 @@ namespace StreamChat.Core.LowLevelClient.API.Internal
                     Event = eventBodyDto,
                 });
 
+        private const int InvalidAuthTokenErrorCode = 40;
+
+        private static readonly HttpMethod PatchHttpMethod = new HttpMethod("PATCH");
+
         private readonly IHttpClient _httpClient;
         private readonly ISerializer _serializer;
         private readonly ILogs _logs;
         private readonly IRequestUriFactory _requestUriFactory;
         private readonly StringBuilder _sb = new StringBuilder();
+        private readonly IStreamChatLowLevelClient _lowLevelClient;
 
-        private void LogRestCall(Uri uri, string endpoint, HttpMethod httpMethod, string response, bool success, string request = null)
+        private HttpContent TryGetHttpContent(object content, out string serializedContent)
+        {
+            serializedContent = default;
+
+            if (content == null)
+            {
+                return null;
+            }
+
+            if (content is HttpContent httpContent)
+            {
+                return httpContent;
+            }
+
+            serializedContent = _serializer.Serialize(content);
+            return new StringContent(serializedContent);
+        }
+
+        private async Task<TResponse> HttpRequest<TResponse>(HttpMethod httpMethod, string endpoint,
+            object requestBody = default, QueryParameters queryParameters = null)
+        {
+            //StreamTodo: perhaps remove this requirement, sometimes we send empty body without any properties
+            if (requestBody == null && IsRequestBodyRequiredByHttpMethod(httpMethod))
+            {
+                throw new ArgumentException($"{nameof(requestBody)} is required by {httpMethod}");
+            }
+
+            var httpContent = TryGetHttpContent(requestBody, out var serializedContent);
+            var logContent = serializedContent ?? httpContent?.ToString();
+
+            if (httpMethod == HttpMethod.Get && serializedContent != null)
+            {
+                queryParameters ??= QueryParameters.Default;
+                queryParameters.Append("payload", serializedContent);
+            }
+
+            var uri = _requestUriFactory.CreateEndpointUri(endpoint, queryParameters);
+
+            LogFutureRequestIfDebug(uri, endpoint, httpMethod, logContent);
+
+            var httpResponse = await ExecuteHttpMethodAsync(httpMethod, uri, httpContent);
+            var responseContent = await httpResponse.Content.ReadAsStringAsync();
+
+            if (!httpResponse.IsSuccessStatusCode)
+            {
+                var apiError = _serializer.Deserialize<APIErrorInternalDTO>(responseContent);
+
+                if (apiError.Code != InvalidAuthTokenErrorCode)
+                {
+                    LogRestCall(uri, endpoint, httpMethod, responseContent, success: false, logContent);
+                    throw new StreamApiException(apiError);
+                }
+
+                if (_lowLevelClient.ConnectionState == ConnectionState.Connected)
+                {
+                    _logs.Info("INTERCEPTOR - DisconnectAsync connection_id = " +
+                               ((IConnectionProvider)_lowLevelClient).ConnectionId);
+                    await _lowLevelClient.DisconnectAsync();
+                }
+
+                _logs.Info("INTERCEPTOR - New Token required, connection: " + _lowLevelClient.ConnectionState);
+
+                const int maxMsToWait = 500;
+                var i = 0;
+                
+                //StreamTodo: we can create cancellation token instead of Task.Delay in loop
+                while (_lowLevelClient.ConnectionState != ConnectionState.Connected)
+                {
+                    i++;
+                    await Task.Delay(1);
+
+                    if (i > maxMsToWait)
+                    {
+                        break;
+                    }
+                }
+
+                if (_lowLevelClient.ConnectionState != ConnectionState.Connected)
+                {
+                    throw new TimeoutException(
+                        "Request reached timout when waiting for client to reconnect after auth token refresh");
+                }
+
+                // Recreate the uri to include new connection id 
+                uri = _requestUriFactory.CreateEndpointUri(endpoint, queryParameters);
+
+                httpResponse = await ExecuteHttpMethodAsync(httpMethod, uri, httpContent);
+                responseContent = await httpResponse.Content.ReadAsStringAsync();
+            }
+
+            try
+            {
+                var response = _serializer.Deserialize<TResponse>(responseContent);
+                LogRestCall(uri, endpoint, httpMethod, responseContent, success: true, logContent);
+                return response;
+            }
+            catch (Exception e)
+            {
+                LogRestCall(uri, endpoint, httpMethod, responseContent, success: false, logContent);
+                throw new StreamDeserializationException(responseContent, typeof(TResponse), e);
+            }
+        }
+
+        private Task<HttpResponseMessage> ExecuteHttpMethodAsync(HttpMethod httpMethod, Uri uri,
+            HttpContent requestContent = default)
+        {
+            if (httpMethod == HttpMethod.Get)
+            {
+                return _httpClient.GetAsync(uri);
+            }
+
+            if (httpMethod == HttpMethod.Post)
+            {
+                return _httpClient.PostAsync(uri, requestContent);
+            }
+
+            if (httpMethod == HttpMethod.Delete)
+            {
+                return _httpClient.DeleteAsync(uri);
+            }
+
+            if (httpMethod == HttpMethod.Put)
+            {
+                return _httpClient.PutAsync(uri, requestContent);
+            }
+
+            if (httpMethod == PatchHttpMethod)
+            {
+                return _httpClient.PatchAsync(uri, requestContent);
+            }
+
+            throw new InvalidOperationException($"Method {httpMethod} is not supported");
+        }
+
+        private static bool IsRequestBodyRequiredByHttpMethod(HttpMethod httpMethod)
+            => httpMethod == HttpMethod.Post || httpMethod == HttpMethod.Put || httpMethod == PatchHttpMethod;
+
+        private void LogFutureRequestIfDebug(Uri uri, string endpoint, HttpMethod httpMethod, string request = null)
+        {
+#if STREAM_DEBUG_ENABLED
+            _sb.Clear();
+
+            _sb.Clear();
+            _sb.Append("API Call: ");
+            _sb.Append(httpMethod);
+            _sb.Append(" ");
+            _sb.Append(endpoint);
+            _sb.Append(Environment.NewLine);
+            _sb.Append("Full uri: ");
+            _sb.Append(uri);
+            _sb.Append(Environment.NewLine);
+            _sb.Append(Environment.NewLine);
+
+            if (request != null)
+            {
+                _sb.AppendLine("Request:");
+                _sb.AppendLine(request);
+                _sb.Append(Environment.NewLine);
+            }
+
+            _logs.Info(_sb.ToString());
+#endif
+        }
+
+        private void LogRestCall(Uri uri, string endpoint, HttpMethod httpMethod, string response, bool success,
+            string request = null)
         {
             _sb.Clear();
             _sb.Append("API Call: ");

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/API/Internal/InternalChannelApi.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/API/Internal/InternalChannelApi.cs
@@ -13,8 +13,8 @@ namespace StreamChat.Core.LowLevelClient.API.Internal
     internal class InternalChannelApi : InternalApiClientBase, IInternalChannelApi
     {
         internal InternalChannelApi(IHttpClient httpClient, ISerializer serializer, ILogs logs,
-            IRequestUriFactory requestUriFactory)
-            : base(httpClient, serializer, logs, requestUriFactory)
+            IRequestUriFactory requestUriFactory, IStreamChatLowLevelClient lowLevelClient)
+            : base(httpClient, serializer, logs, requestUriFactory, lowLevelClient)
         {
         }
 

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/API/Internal/InternalMessageApi.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/API/Internal/InternalMessageApi.cs
@@ -12,8 +12,8 @@ namespace StreamChat.Core.LowLevelClient.API.Internal
     internal class InternalMessageApi : InternalApiClientBase, IInternalMessageApi
     {
         public InternalMessageApi(IHttpClient httpClient, ISerializer serializer, ILogs logs,
-            IRequestUriFactory requestUriFactory)
-            : base(httpClient, serializer, logs, requestUriFactory)
+            IRequestUriFactory requestUriFactory, IStreamChatLowLevelClient lowLevelClient)
+            : base(httpClient, serializer, logs, requestUriFactory, lowLevelClient)
         {
         }
 

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/API/Internal/InternalModerationApi.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/API/Internal/InternalModerationApi.cs
@@ -11,8 +11,8 @@ namespace StreamChat.Core.LowLevelClient.API.Internal
     internal class InternalModerationApi : InternalApiClientBase, IInternalModerationApi
     {
         public InternalModerationApi(IHttpClient httpClient, ISerializer serializer, ILogs logs,
-            IRequestUriFactory requestUriFactory)
-            : base(httpClient, serializer, logs, requestUriFactory)
+            IRequestUriFactory requestUriFactory, IStreamChatLowLevelClient lowLevelClient)
+            : base(httpClient, serializer, logs, requestUriFactory, lowLevelClient)
         {
         }
 

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/API/Internal/InternalUserApi.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/API/Internal/InternalUserApi.cs
@@ -11,8 +11,8 @@ namespace StreamChat.Core.LowLevelClient.API.Internal
     internal class InternalUserApi : InternalApiClientBase, IInternalUserApi
     {
         public InternalUserApi(IHttpClient httpClient, ISerializer serializer, ILogs logs,
-            IRequestUriFactory requestUriFactory)
-            : base(httpClient, serializer, logs, requestUriFactory)
+            IRequestUriFactory requestUriFactory, IStreamChatLowLevelClient lowLevelClient)
+            : base(httpClient, serializer, logs, requestUriFactory, lowLevelClient)
         {
         }
 

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/IStreamChatLowLevelClient.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/IStreamChatLowLevelClient.cs
@@ -76,6 +76,6 @@ namespace StreamChat.Core.LowLevelClient
 
         void ConnectUser(AuthCredentials userAuthCredentials);
 
-        Task DisconnectAsync();
+        Task DisconnectAsync(bool permanently = false);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/StreamChatLowLevelClient.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/StreamChatLowLevelClient.cs
@@ -4,6 +4,7 @@ using System.Net.WebSockets;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using StreamChat.Core.API;
 using StreamChat.Core.API.Internal;
@@ -11,6 +12,7 @@ using StreamChat.Core.Auth;
 using StreamChat.Core.Configs;
 using StreamChat.Core.Exceptions;
 using StreamChat.Core.InternalDTO.Events;
+using StreamChat.Core.InternalDTO.Models;
 using StreamChat.Core.LowLevelClient.API;
 using StreamChat.Core.LowLevelClient.API.Internal;
 using StreamChat.Core.LowLevelClient.Events;
@@ -181,10 +183,12 @@ namespace StreamChat.Core.LowLevelClient
             }
         }
 
-        public ReconnectStrategy ReconnectStrategy { get; private set; }
-        public float ReconnectConstantInterval { get; private set; } = 3;
-        public float ReconnectExponentialMinInterval { get; private set; } = 1;
-        public float ReconnectExponentialMaxInterval { get; private set; } = 1024;
+        //StreamTodo: wrap all params in a ReconnectPolicy object
+        public ReconnectStrategy ReconnectStrategy { get; private set; } = ReconnectStrategy.Exponential;
+        public float ReconnectConstantInterval { get; private set; } = 1;
+        public float ReconnectExponentialMinInterval { get; private set; } = 0.01f;
+        public float ReconnectExponentialMaxInterval { get; private set; } = 64;
+        public int ReconnectMaxInstantTrials { get; private set; } = 10; //StreamTodo: allow to control this by user
         public double? NextReconnectTime { get; private set; }
 
         /// <summary>
@@ -249,7 +253,6 @@ namespace StreamChat.Core.LowLevelClient
             IHttpClient httpClient, ISerializer serializer, ITimeService timeService, IApplicationInfo applicationInfo,
             ILogs logs, IStreamClientConfig config)
         {
-            _config = config;
             _authCredentials = authCredentials;
             _websocketClient = websocketClient ?? throw new ArgumentNullException(nameof(websocketClient));
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
@@ -264,18 +267,22 @@ namespace StreamChat.Core.LowLevelClient
             _requestUriFactory = new RequestUriFactory(authProvider: this, connectionProvider: this, _serializer);
 
             _httpClient.AddDefaultCustomHeader("stream-auth-type", DefaultStreamAuthType);
-            var header = BuildStreamHeader(applicationInfo);
+            var header = BuildStreamClientHeader(applicationInfo);
             _httpClient.AddDefaultCustomHeader("X-Stream-Client", header);
 
             _websocketClient.ConnectionFailed += OnWebsocketsConnectionFailed;
-            //_websocketClient.Connected += OnWebsocketsConnected;
             _websocketClient.Disconnected += OnWebsocketDisconnected;
 
-            InternalChannelApi = new InternalChannelApi(httpClient, serializer, logs, _requestUriFactory);
-            InternalMessageApi = new InternalMessageApi(httpClient, serializer, logs, _requestUriFactory);
-            InternalModerationApi = new InternalModerationApi(httpClient, serializer, logs, _requestUriFactory);
-            InternalUserApi = new InternalUserApi(httpClient, serializer, logs, _requestUriFactory);
-            InternalDeviceApi = new InternalDeviceApi(httpClient, serializer, logs, _requestUriFactory);
+            InternalChannelApi
+                = new InternalChannelApi(httpClient, serializer, logs, _requestUriFactory, lowLevelClient: this);
+            InternalMessageApi
+                = new InternalMessageApi(httpClient, serializer, logs, _requestUriFactory, lowLevelClient: this);
+            InternalModerationApi
+                = new InternalModerationApi(httpClient, serializer, logs, _requestUriFactory, lowLevelClient: this);
+            InternalUserApi
+                = new InternalUserApi(httpClient, serializer, logs, _requestUriFactory, lowLevelClient: this);
+            InternalDeviceApi
+                = new InternalDeviceApi(httpClient, serializer, logs, _requestUriFactory, lowLevelClient: this);
 
             ChannelApi = new ChannelApi(InternalChannelApi);
             MessageApi = new MessageApi(InternalMessageApi);
@@ -290,28 +297,24 @@ namespace StreamChat.Core.LowLevelClient
 
         public void ConnectUser(AuthCredentials userAuthCredentials)
         {
-            SetUser(userAuthCredentials);
+            SetConnectionCredentials(userAuthCredentials);
             Connect();
-        }
-
-        public async Task DisconnectAsync()
-        {
-            //StreamTodo: remove this hack, if user issues a disconnect it should gracefully switch to permanent disconnect and to automatically reconnect
-            NextReconnectTime = float.MaxValue;
-            await _websocketClient.DisconnectAsync(WebSocketCloseStatus.NormalClosure, "User called Disconnect");
         }
 
         public void Connect()
         {
-            SetUser(_authCredentials);
+            SetConnectionCredentials(_authCredentials);
 
             if (!ConnectionState.IsValidToConnect())
             {
                 throw new InvalidOperationException("Attempted to connect, but client is in state: " + ConnectionState);
             }
 
+            TryCancelWaitingForUserConnection();
+
             NextReconnectTime = default;
 
+            //StreamTodo: hidden dependency on SetUser being called
             var connectionUri = _requestUriFactory.CreateConnectionUri();
 
             _logs.Info($"Attempt to connect");
@@ -319,6 +322,19 @@ namespace StreamChat.Core.LowLevelClient
             ConnectionState = ConnectionState.Connecting;
 
             _websocketClient.ConnectAsync(connectionUri).LogIfFailed(_logs);
+        }
+
+        public async Task DisconnectAsync(bool permanently = false)
+        {
+            TryCancelWaitingForUserConnection();
+            //StreamTodo: remove this, this cannot be used when internal disconnect due to expired token. Perhaps we should allow user to Suspend() and Unsupend() the client reconnection
+
+            if (permanently)
+            {
+                NextReconnectTime = float.MaxValue;
+            }
+            
+            await _websocketClient.DisconnectAsync(WebSocketCloseStatus.NormalClosure, "User called Disconnect");
         }
 
         public void Update(float deltaTime)
@@ -378,8 +394,9 @@ namespace StreamChat.Core.LowLevelClient
         {
             ConnectionState = ConnectionState.Closing;
 
+            TryCancelWaitingForUserConnection();
+
             _websocketClient.ConnectionFailed -= OnWebsocketsConnectionFailed;
-            _websocketClient.Connected -= OnWebsocketsConnected;
             _websocketClient.Disconnected -= OnWebsocketDisconnected;
             _websocketClient?.Dispose();
         }
@@ -396,6 +413,50 @@ namespace StreamChat.Core.LowLevelClient
         internal IInternalModerationApi InternalModerationApi { get; }
         internal InternalUserApi InternalUserApi { get; }
         internal IInternalDeviceApi InternalDeviceApi { get; }
+
+        internal async Task<OwnUserInternalDTO> ConnectUserAsync(string apiKey, string userId,
+            ITokenProvider tokenProvider, CancellationToken cancellationToken = default)
+        {
+            if (!ConnectionState.IsValidToConnect())
+            {
+                throw new InvalidOperationException("Attempted to connect, but client is in state: " + ConnectionState);
+            }
+
+            _tokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
+            SetPartialConnectionCredentials(apiKey, userId);
+
+            TryCancelWaitingForUserConnection();
+
+            ConnectionState = ConnectionState.Connecting;
+
+            _connectUserCancellationToken = cancellationToken;
+
+            _connectUserCancellationTokenSource
+                = CancellationTokenSource.CreateLinkedTokenSource(_connectUserCancellationToken);
+            _connectUserCancellationTokenSource.Token.Register(TryCancelWaitingForUserConnection);
+
+            _connectUserTaskSource = new TaskCompletionSource<OwnUserInternalDTO>();
+
+            try
+            {
+                await RefreshAuthTokenFromProvider();
+
+                NextReconnectTime = default;
+
+                var connectionUri = _requestUriFactory.CreateConnectionUri();
+
+                await _websocketClient.ConnectAsync(connectionUri);
+
+                var ownUserDto = await _connectUserTaskSource.Task;
+                return ownUserDto;
+            }
+            catch (Exception e)
+            {
+                _logs.Exception(e);
+                ConnectionState = ConnectionState.Disconnected;
+                throw;
+            }
+        }
 
         private const string DefaultStreamAuthType = "jwt";
         private const int HealthCheckMaxWaitingTime = 30;
@@ -417,6 +478,10 @@ namespace StreamChat.Core.LowLevelClient
 
         private readonly object _websocketConnectionFailedFlagLock = new object();
 
+        private TaskCompletionSource<OwnUserInternalDTO> _connectUserTaskSource;
+        private CancellationToken _connectUserCancellationToken;
+        private CancellationTokenSource _connectUserCancellationTokenSource;
+
         private AuthCredentials _authCredentials;
 
         private ConnectionState _connectionState;
@@ -427,8 +492,42 @@ namespace StreamChat.Core.LowLevelClient
 
         private bool _websocketConnectionFailed;
         private int _reconnectAttempt;
+        private ITokenProvider _tokenProvider;
+        
+        private async Task RefreshAuthTokenFromProvider()
+        {
+#if STREAM_DEBUG_ENABLED
+            _logs.Info($"Request new auth token for user `{_authCredentials.UserId}`");
+#endif
 
-        private void OnWebsocketsConnected() => _logs.Info("Websockets Connected");
+            var token = await _tokenProvider.GetTokenAsync(_authCredentials.UserId);
+
+#if STREAM_DEBUG_ENABLED
+            _logs.Info($"auth token received for user `{_authCredentials.UserId}`: " + token);
+#endif
+
+            _authCredentials = _authCredentials.CreateWithNewUserToken(token);
+            SetConnectionCredentials(_authCredentials);
+        }
+
+        private void TryCancelWaitingForUserConnection()
+        {
+            if (_connectUserTaskSource == null)
+            {
+                return;
+            }
+
+            var isConnectTaskRunning = _connectUserTaskSource.Task != null && !_connectUserTaskSource.Task.IsCompleted;
+            var isCancellationRequested = _connectUserCancellationTokenSource.IsCancellationRequested;
+
+            if (isConnectTaskRunning && !isCancellationRequested)
+            {
+#if STREAM_DEBUG_ENABLED
+                _logs.Info($"Try Cancel {_connectUserTaskSource}");
+#endif
+                _connectUserTaskSource.TrySetCanceled();
+            }
+        }
 
         private void OnWebsocketDisconnected()
         {
@@ -462,6 +561,8 @@ namespace StreamChat.Core.LowLevelClient
 
             ConnectionState = ConnectionState.Disconnected;
 
+            //StreamTodo: what about ConnectUserAsync and passed cancellation token
+
             TryScheduleReconnect();
         }
 
@@ -478,6 +579,8 @@ namespace StreamChat.Core.LowLevelClient
             _lastHealthCheckReceivedTime = _timeService.Time;
             _reconnectAttempt = 0;
             ConnectionState = ConnectionState.Connected;
+
+            _connectUserTaskSource?.SetResult(eventHealthCheckInternalDto.Me);
 
             _logs.Info("Connection confirmed by server with connection id: " + _connectionId);
             Connected?.Invoke(healthCheckEvent.Me);
@@ -497,7 +600,15 @@ namespace StreamChat.Core.LowLevelClient
             }
 
             _reconnectAttempt++;
-            Connect();
+
+            if (_tokenProvider != null)
+            {
+                ConnectUserAsync(_authCredentials.ApiKey, _authCredentials.UserId, _tokenProvider).LogIfFailed();
+            }
+            else
+            {
+                Connect();
+            }
         }
 
         private bool TryScheduleReconnect()
@@ -526,6 +637,12 @@ namespace StreamChat.Core.LowLevelClient
                     throw new ArgumentOutOfRangeException();
             }
 
+            if (ReconnectStrategy != ReconnectStrategy.Never && _reconnectAttempt <= ReconnectMaxInstantTrials)
+            {
+                NextReconnectTime = _timeService.Time;
+
+            }
+            
             if (NextReconnectTime.HasValue)
             {
                 ConnectionState = ConnectionState.WaitToReconnect;
@@ -585,7 +702,8 @@ namespace StreamChat.Core.LowLevelClient
             RegisterEventType<EventMemberUpdatedInternalDTO, EventMemberUpdated>(WSEventType.MemberUpdated,
                 (e, dto) => MemberUpdated?.Invoke(e), dto => InternalMemberUpdated?.Invoke(dto));
 
-            RegisterEventType<EventUserPresenceChangedInternalDTO, EventUserPresenceChanged>(WSEventType.UserPresenceChanged,
+            RegisterEventType<EventUserPresenceChangedInternalDTO, EventUserPresenceChanged>(
+                WSEventType.UserPresenceChanged,
                 (e, dto) => UserPresenceChanged?.Invoke(e), dto => InternalUserPresenceChanged?.Invoke(dto));
             RegisterEventType<EventUserUpdatedInternalDTO, EventUserUpdated>(WSEventType.UserUpdated,
                 (e, dto) => UserUpdated?.Invoke(e), dto => InternalUserUpdated?.Invoke(dto));
@@ -792,7 +910,7 @@ namespace StreamChat.Core.LowLevelClient
                 .Replace('/', '_')
                 .Trim('=');
 
-        private void SetUser(AuthCredentials credentials)
+        private void SetConnectionCredentials(AuthCredentials credentials)
         {
             if (credentials.IsAnyEmpty())
             {
@@ -802,6 +920,12 @@ namespace StreamChat.Core.LowLevelClient
 
             _authCredentials = credentials;
             _httpClient.SetDefaultAuthenticationHeader(credentials.UserToken);
+        }
+
+        //StreamTodo: make it more clear that we either receive full set of credentials or apiKey, userId and the token provider
+        private void SetPartialConnectionCredentials(string apiKey, string userId)
+        {
+            _authCredentials = new AuthCredentials(apiKey, userId, string.Empty);
         }
 
         private void LogErrorIfUpdateIsNotBeingCalled()
@@ -816,8 +940,8 @@ namespace StreamChat.Core.LowLevelClient
                 }
             });
         }
-        
-        private static string BuildStreamHeader(IApplicationInfo applicationInfo)
+
+        private static string BuildStreamClientHeader(IApplicationInfo applicationInfo)
         {
             var sb = new StringBuilder();
             sb.Append($"stream-chat-unity-client-");
@@ -827,7 +951,7 @@ namespace StreamChat.Core.LowLevelClient
             sb.Append("os=");
             sb.Append(applicationInfo.OperatingSystem);
             sb.Append("|");
-            
+
             sb.Append("platform=");
             sb.Append(applicationInfo.Platform);
             sb.Append("|");
@@ -843,14 +967,14 @@ namespace StreamChat.Core.LowLevelClient
             sb.Append("screen_size=");
             sb.Append(applicationInfo.ScreenSize);
             sb.Append("|");
-            
+
             sb.Append("memory_size=");
             sb.Append(applicationInfo.MemorySize);
             sb.Append("|");
-            
+
             sb.Append("graphics_memory_size=");
             sb.Append(applicationInfo.GraphicsMemorySize);
-            
+
             return sb.ToString();
         }
     }

--- a/Assets/Plugins/StreamChat/Core/StreamChat.Core.asmdef
+++ b/Assets/Plugins/StreamChat/Core/StreamChat.Core.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "StreamChat.Core",
-    "rootNamespace": "StreamChat.Core",
+    "rootNamespace": "",
     "references": [
         "GUID:45f99e6948181224abd5a0b0ca925d1b"
     ],

--- a/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
@@ -60,6 +60,7 @@ namespace StreamChat.Core
         public ConnectionState ConnectionState => InternalLowLevelClient.ConnectionState;
         
         public bool IsConnected => InternalLowLevelClient.ConnectionState == ConnectionState.Connected;
+        public bool IsConnecting => InternalLowLevelClient.ConnectionState == ConnectionState.Connecting;
 
         public IStreamLocalUserData LocalUserData => _localUserData;
 
@@ -94,6 +95,17 @@ namespace StreamChat.Core
             gameObjectRunner.RunChatInstance(client);
             return client;
         }
+
+        /// <summary>
+        /// Create instance of <see cref="ITokenProvider"/>
+        /// </summary>
+        /// <param name="urlFactory">Delegate that will return a valid url that return JWT auth token for a given user ID</param>
+        /// <example>
+        /// <code>
+        /// StreamChatClient.CreateDefaultTokenProvider(userId => new Uri($"https:your-awesome-page.com/get_token?userId={userId}"));
+        /// </code>
+        /// </example>
+        public static ITokenProvider CreateDefaultTokenProvider(TokenProvider.TokenUriHandler urlFactory) => StreamDependenciesFactory.CreateTokenProvider(urlFactory);
 
         /// <summary>
         /// Create a new instance of <see cref="IStreamChatLowLevelClient"/> with custom provided dependencies.
@@ -140,8 +152,24 @@ namespace StreamChat.Core
 
             return ConnectUserAsync(new AuthCredentials(apiKey, userId, userAuthToken), cancellationToken);
         }
+        
+        public async Task<IStreamLocalUserData> ConnectUserAsync(string apiKey, string userId, ITokenProvider tokenProvider,
+            CancellationToken cancellationToken = default)
+        {
+            StreamAsserts.AssertNotNullOrEmpty(apiKey, nameof(apiKey));
+            StreamAsserts.AssertNotNullOrEmpty(userId, nameof(userId));
+            StreamAsserts.AssertNotNull(tokenProvider, nameof(tokenProvider));
 
-        public Task DisconnectUserAsync() => InternalLowLevelClient.DisconnectAsync();
+            var ownUserDto = await InternalLowLevelClient.ConnectUserAsync(apiKey, userId, tokenProvider, cancellationToken);
+            return UpdateLocalUser(ownUserDto);
+        }
+
+        //StreamTodo: test scenario: ConnectUserAsync and immediately all DisconnectUserAsync
+        public Task DisconnectUserAsync()
+        {
+            TryCancelWaitingForUserConnection();
+            return InternalLowLevelClient.DisconnectAsync();
+        }
 
         public bool IsLocalUser(IStreamUser user) => LocalUserData.User == user;
 
@@ -440,7 +468,7 @@ namespace StreamChat.Core
 
         internal StreamChatLowLevelClient InternalLowLevelClient { get; }
 
-        internal void UpdateLocalUser(OwnUserInternalDTO ownUserInternalDto)
+        internal IStreamLocalUserData UpdateLocalUser(OwnUserInternalDTO ownUserInternalDto)
         {
             _localUserData = _cache.TryCreateOrUpdate(ownUserInternalDto);
 
@@ -451,6 +479,8 @@ namespace StreamChat.Core
                 var isMuted = LocalUserData.ChannelMutes.Any(_ => _.Channel == channel);
                 channel.Muted = isMuted;
             }
+
+            return _localUserData;
         }
 
         internal Task RefreshChannelState(string cid)
@@ -463,7 +493,7 @@ namespace StreamChat.Core
 
             return GetOrCreateChannelWithIdAsync(channel.Type, channel.Id);
         }
-
+        
         private readonly ILogs _logs;
         private readonly ITimeService _timeService;
         private readonly ICache _cache;
@@ -474,7 +504,23 @@ namespace StreamChat.Core
         private bool _isDisposed;
 
         /// <summary>
-        /// Use the <see cref="CreateDefaultClient"/> to create the client instance
+        /// Use the <see cref="CreateDefaultClient"/> to create the default client instance.
+        /// <example>
+        /// Default example::
+        /// <code>
+        /// var streamChatClient = StreamChatClient.CreateDefaultClient();
+        /// </code>
+        /// </example>
+        /// <example>
+        /// Example with custom config:
+        /// <code>
+        /// var streamChatClient = StreamChatClient.CreateDefaultClient(new StreamClientConfig
+        /// {
+        ///     LogLevel = StreamLogLevel.Debug
+        /// });
+        /// </code>
+        /// </example>
+        /// In case you want to inject custom dependencies into the chat client you can use the <see cref="CreateClientWithCustomDependencies"/>
         /// </summary>
         private StreamChatClient(IWebsocketClient websocketClient, IHttpClient httpClient, ISerializer serializer, 
             ITimeService timeService, IApplicationInfo applicationInfo, ILogs logs, IStreamClientConfig config)
@@ -500,7 +546,7 @@ namespace StreamChat.Core
         private void TryCancelWaitingForUserConnection()
         {
             var isConnectTaskRunning = _connectUserTaskSource?.Task != null && !_connectUserTaskSource.Task.IsCompleted;
-            var isCancellationRequested = _connectUserCancellationTokenSource.IsCancellationRequested;
+            var isCancellationRequested = _connectUserCancellationTokenSource?.IsCancellationRequested ?? false;
 
             if (isConnectTaskRunning && !isCancellationRequested)
             {
@@ -523,12 +569,8 @@ namespace StreamChat.Core
             }
             finally
             {
-                if (_connectUserTaskSource == null)
-                {
-                    _logs.Error(
-                        $"{nameof(OnConnected)} expected {nameof(_connectUserTaskSource)} not null");
-                }
-                else
+                // This will be null if the ConnectUserAsync with token provider was used
+                if (_connectUserTaskSource != null)
                 {
                     _connectUserTaskSource.SetResult(LocalUserData);
                 }

--- a/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
@@ -573,6 +573,7 @@ namespace StreamChat.Core
                 if (_connectUserTaskSource != null)
                 {
                     _connectUserTaskSource.SetResult(LocalUserData);
+                    _connectUserTaskSource = null;
                 }
             }
         }

--- a/Assets/Plugins/StreamChat/EditorTools/StreamEditorTools.cs
+++ b/Assets/Plugins/StreamChat/EditorTools/StreamEditorTools.cs
@@ -1,11 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
-using StreamChat.EditorTools.Builders;
-using StreamChat.Core;
 using StreamChat.Core.LowLevelClient;
+using StreamChat.EditorTools.Builders;
 using StreamChat.EditorTools.DefineSymbols;
 using UnityEditor;
 using UnityEngine;
@@ -15,18 +11,11 @@ namespace StreamChat.EditorTools
     public static class StreamEditorTools
     {
         [MenuItem(MenuPrefix + "Toggle Stream Integration & Unit Tests Enabled")]
-        public static void ToggleStreamTestsEnabledCompilerFlag()
-        {
-            var unityDefineSymbols = new UnityDefineSymbolsFactory().CreateDefault();
+        public static void ToggleStreamTestsEnabledCompilerFlag() => ToggleCompilerFlag(StreamTestsEnabledCompilerFlag);
 
-            var activeBuildTarget = EditorUserBuildSettings.activeBuildTarget;
-
-            var symbols = unityDefineSymbols.GetScriptingDefineSymbols(activeBuildTarget).ToList();
-
-            var nextState = !symbols.Contains(StreamTestsEnabledCompilerFlag);
-
-            SetStreamTestsEnabledCompilerFlag(nextState);
-        }
+        [MenuItem(MenuPrefix + "Toggle Stream Debug Mode Enabled")]
+        public static void ToggleStreamDebugModeCompilerFlag()
+            => ToggleCompilerFlag(StreamDebugModeEnabledCompilerFlag);
 
         [MenuItem(MenuPrefix + "Open " + nameof(SpriteAtlasUtilityEditor))]
         public static void ShowSpriteAtlasUtilityEditorWindow()
@@ -46,9 +35,22 @@ namespace StreamChat.EditorTools
         }
 
         public static void EnableStreamTestsEnabledCompilerFlag()
-            => SetStreamTestsEnabledCompilerFlag(true);
+            => SetStreamTestsEnabledCompilerFlag(StreamTestsEnabledCompilerFlag, true);
 
-        public static void SetStreamTestsEnabledCompilerFlag(bool enabled)
+        private static void ToggleCompilerFlag(string flagKeyword)
+        {
+            var unityDefineSymbols = new UnityDefineSymbolsFactory().CreateDefault();
+
+            var activeBuildTarget = EditorUserBuildSettings.activeBuildTarget;
+
+            var symbols = unityDefineSymbols.GetScriptingDefineSymbols(activeBuildTarget).ToList();
+
+            var nextState = !symbols.Contains(flagKeyword);
+
+            SetStreamTestsEnabledCompilerFlag(flagKeyword, nextState);
+        }
+
+        public static void SetStreamTestsEnabledCompilerFlag(string flagKeyword, bool enabled)
         {
             var unityDefineSymbols = new UnityDefineSymbolsFactory().CreateDefault();
 
@@ -58,26 +60,27 @@ namespace StreamChat.EditorTools
 
             var prevCombined = string.Join(", ", symbols);
 
-            if (enabled && !symbols.Contains(StreamTestsEnabledCompilerFlag))
+            if (enabled && !symbols.Contains(flagKeyword))
             {
-                symbols.Add(StreamTestsEnabledCompilerFlag);
+                symbols.Add(flagKeyword);
             }
 
-            if (!enabled && symbols.Contains(StreamTestsEnabledCompilerFlag))
+            if (!enabled && symbols.Contains(flagKeyword))
             {
-                symbols.Remove(StreamTestsEnabledCompilerFlag);
+                symbols.Remove(flagKeyword);
             }
 
             var currentCombined = string.Join(", ", symbols);
 
             unityDefineSymbols.SetScriptingDefineSymbols(activeBuildTarget, symbols);
 
-            Debug.Log($"Editor scripting define symbols have been modified from: `{prevCombined}` to: `{currentCombined}` for named build target: `{Enum.GetName(typeof(BuildTarget), activeBuildTarget)}`");
+            Debug.Log(
+                $"Editor scripting define symbols have been modified from: `{prevCombined}` to: `{currentCombined}` for named build target: `{Enum.GetName(typeof(BuildTarget), activeBuildTarget)}`");
         }
 
         private const string MenuPrefix = "Tools/" + StreamChatLowLevelClient.MenuPrefix;
 
         private const string StreamTestsEnabledCompilerFlag = "STREAM_TESTS_ENABLED";
+        private const string StreamDebugModeEnabledCompilerFlag = "STREAM_DEBUG_ENABLED";
     }
 }
-

--- a/Assets/Plugins/StreamChat/Libs/Auth/AuthCredentials.cs
+++ b/Assets/Plugins/StreamChat/Libs/Auth/AuthCredentials.cs
@@ -19,5 +19,7 @@ namespace StreamChat.Libs.Auth
         }
 
         public bool IsAnyEmpty() => ApiKey.IsNullOrEmpty() || UserId.IsNullOrEmpty() || UserToken.IsNullOrEmpty();
+
+        public AuthCredentials CreateWithNewUserToken(string token) => new AuthCredentials(ApiKey, UserId, token);
     }
 }

--- a/Assets/Plugins/StreamChat/Libs/Auth/ITokenProvider.cs
+++ b/Assets/Plugins/StreamChat/Libs/Auth/ITokenProvider.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+using UnityEngine;
+
+namespace StreamChat.Libs.Auth
+{
+    /// <summary>
+    /// Providers JWT authorization token for Stream Chat
+    /// </summary>
+    public interface ITokenProvider
+    {
+        /// <summary>
+        /// Get JWT token for the provided user id
+        /// </summary>
+        /// <remarks>https://getstream.io/chat/docs/unity/tokens_and_authentication/?language=unity#token-providers</remarks>
+        Task<string> GetTokenAsync(string userId);
+    }
+}

--- a/Assets/Plugins/StreamChat/Libs/Auth/ITokenProvider.cs.meta
+++ b/Assets/Plugins/StreamChat/Libs/Auth/ITokenProvider.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d10c5bf97a6d4222a170709b8054c2e8
+timeCreated: 1670507332

--- a/Assets/Plugins/StreamChat/Libs/Auth/TokenProvider.cs
+++ b/Assets/Plugins/StreamChat/Libs/Auth/TokenProvider.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading.Tasks;
+using StreamChat.Libs.Http;
+
+namespace StreamChat.Libs.Auth
+{
+    /// <summary>
+    /// Simple implementation of <see cref="ITokenProvider"/>
+    /// You can create instance of this object using <see cref="StreamDependenciesFactory.CreateTokenProvider"/>
+    /// </summary>
+    public class TokenProvider : ITokenProvider
+    {
+        public delegate Uri TokenUriHandler(string userId);
+
+        public TokenProvider(IHttpClient httpClient, TokenUriHandler urlFactory)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _urlFactory = urlFactory ?? throw new ArgumentNullException(nameof(urlFactory));
+        }
+
+        public async Task<string> GetTokenAsync(string userId)
+        {
+            var uri = _urlFactory(userId);
+            var response = await _httpClient.GetAsync(uri);
+            var responseContent = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new Exception("Token provider failed with status code: " + response.StatusCode +
+                                    " and response body: " + responseContent);
+            }
+
+            return responseContent;
+        }
+
+        private readonly IHttpClient _httpClient;
+        private readonly TokenUriHandler _urlFactory;
+    }
+}

--- a/Assets/Plugins/StreamChat/Libs/Auth/TokenProvider.cs.meta
+++ b/Assets/Plugins/StreamChat/Libs/Auth/TokenProvider.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ce1ec65eef8149388fbaa1a8d8bc64da
+timeCreated: 1671029915

--- a/Assets/Plugins/StreamChat/Libs/Http/HttpClientAdapter.cs
+++ b/Assets/Plugins/StreamChat/Libs/Http/HttpClientAdapter.cs
@@ -21,30 +21,18 @@ namespace StreamChat.Libs.Http
         public void AddDefaultCustomHeader(string key, string value)
             => _httpClient.DefaultRequestHeaders.Add(key, value);
 
-        public Task<HttpResponseMessage> GetAsync(Uri uri)
-            => _httpClient.GetAsync(uri);
+        public Task<HttpResponseMessage> GetAsync(Uri uri) => _httpClient.GetAsync(uri);
 
-        public Task<HttpResponseMessage> PostAsync(Uri uri, string content)
-            => _httpClient.PostAsync(uri, new StringContent(content));
+        public Task<HttpResponseMessage> PostAsync(Uri uri, HttpContent content) => _httpClient.PostAsync(uri, content);
 
-        public Task<HttpResponseMessage> PostAsync(Uri uri, HttpContent content)
-            => _httpClient.PostAsync(uri, content);
+        public Task<HttpResponseMessage> PutAsync(Uri uri, HttpContent content)
+            => _httpClient.PutAsync(uri, content);
 
-        public Task<HttpResponseMessage> PostAsync(Uri uri, MultipartFormDataContent content)
-            => _httpClient.PostAsync(uri, content);
-
-        public Task<HttpResponseMessage> PostAsync(Uri uri, ByteArrayContent content)
-            => _httpClient.PostAsync(uri, content);
-
-        public Task<HttpResponseMessage> PutAsync(Uri uri, string content)
-            => _httpClient.PutAsync(uri, new StringContent(content));
-
-        public Task<HttpResponseMessage> PatchAsync(Uri uri, string content)
+        public Task<HttpResponseMessage> PatchAsync(Uri uri, HttpContent content)
             => _httpClient.SendAsync(new HttpRequestMessage(new HttpMethod("PATCH"), uri)
-                { Content = new StringContent(content) });
+                { Content = content });
 
-        public Task<HttpResponseMessage> DeleteAsync(Uri uri)
-            => _httpClient.DeleteAsync(uri);
+        public Task<HttpResponseMessage> DeleteAsync(Uri uri) => _httpClient.DeleteAsync(uri);
 
         private readonly HttpClient _httpClient;
     }

--- a/Assets/Plugins/StreamChat/Libs/Http/IHttpClient.cs
+++ b/Assets/Plugins/StreamChat/Libs/Http/IHttpClient.cs
@@ -13,20 +13,14 @@ namespace StreamChat.Libs.Http
 
         void AddDefaultCustomHeader(string key, string value);
 
-        Task<HttpResponseMessage> PostAsync(Uri uri, ByteArrayContent content);
-
-        Task<HttpResponseMessage> PostAsync(Uri uri, string content);
-
-        Task<HttpResponseMessage> DeleteAsync(Uri uri);
-
         Task<HttpResponseMessage> GetAsync(Uri uri);
 
         Task<HttpResponseMessage> PostAsync(Uri uri, HttpContent content);
 
-        Task<HttpResponseMessage> PostAsync(Uri uri, MultipartFormDataContent content);
+        Task<HttpResponseMessage> PutAsync(Uri uri, HttpContent content);
 
-        Task<HttpResponseMessage> PutAsync(Uri uri, string content);
+        Task<HttpResponseMessage> PatchAsync(Uri uri, HttpContent content);
 
-        Task<HttpResponseMessage> PatchAsync(Uri uri, string content);
+        Task<HttpResponseMessage> DeleteAsync(Uri uri);
     }
 }

--- a/Assets/Plugins/StreamChat/Libs/StreamChat.Libs.asmdef
+++ b/Assets/Plugins/StreamChat/Libs/StreamChat.Libs.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "StreamChat.Libs",
-    "rootNamespace": "StreamChat.Libs",
+    "rootNamespace": "",
     "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Plugins/StreamChat/Libs/StreamDependenciesFactory.cs
+++ b/Assets/Plugins/StreamChat/Libs/StreamDependenciesFactory.cs
@@ -1,7 +1,8 @@
 ﻿using StreamChat.Libs.AppInfo;
+using StreamChat.Libs.Auth;
+using StreamChat.Libs.ChatInstanceRunner;
 using StreamChat.Libs.Http;
 using StreamChat.Libs.Logs;
-using StreamChat.Libs.ChatInstanceRunner;
 using StreamChat.Libs.Serialization;
 using StreamChat.Libs.Time;
 using StreamChat.Libs.Websockets;
@@ -28,6 +29,8 @@ namespace StreamChat.Libs
         public static ITimeService CreateTimeService() => new UnityTime();
 
         public static IApplicationInfo CreateApplicationInfo() => new UnityApplicationInfo();
+        
+        public static ITokenProvider CreateTokenProvider(TokenProvider.TokenUriHandler urlFactory) => new TokenProvider(CreateHttpClient(), urlFactory);
 
         public static IStreamChatClientRunner CreateChatClientRunner()
         {

--- a/Assets/Plugins/StreamChat/Libs/Utils/TaskUtils.cs
+++ b/Assets/Plugins/StreamChat/Libs/Utils/TaskUtils.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Text;
 using System.Threading.Tasks;
 using StreamChat.Libs.Logs;
 using UnityEngine;
@@ -6,16 +8,56 @@ namespace StreamChat.Libs.Utils
 {
     public static class TaskUtils
     {
-        public static void LogIfFailed(this Task t, ILogs logger) 
-            => t.ContinueWith(_ => logger.Exception(_.Exception.Flatten()),
-            TaskContinuationOptions.OnlyOnFaulted);
-        
+        public static void LogIfFailed(this Task t, ILogs logger)
+            => t.ContinueWith(_ =>
+                {
+                    if (!_.IsFaulted)
+                    {
+                        return;
+                    }
+
+                    Debug.LogException(_.Exception);
+                },
+                TaskScheduler.FromCurrentSynchronizationContext());
+
         /// <summary>
         /// Log exception thrown by this task with Debug.LogException
         /// </summary>
         /// <param name="t"></param>
-        public static void LogIfFailed(this Task t) 
-            => t.ContinueWith(_ => Debug.LogException(_.Exception.Flatten()),
-            TaskContinuationOptions.OnlyOnFaulted);
+        public static void LogIfFailed(this Task t)
+            => t.ContinueWith(_ =>
+                {
+                    if (!_.IsFaulted)
+                    {
+                        return;
+                    }
+
+                    //Skip Debug.LogException because it doesn't print well nested exceptions, it just prints the most inner one
+                    _sb.Length = 0;
+                    Exception exception = _.Exception.Flatten();
+                    while (exception != null)
+                    {
+                        if (exception is AggregateException)
+                        {
+                            exception = exception.InnerException;
+                            continue;
+                        }
+                        _sb.AppendLine(exception.ToString());
+                        _sb.AppendLine(exception.StackTrace);
+                        _sb.AppendLine(Environment.NewLine);
+                        _sb.AppendLine(Environment.NewLine);
+                        
+                        exception = exception.InnerException;
+                    }
+
+                    if (_sb.Length > 0)
+                    {
+                        Debug.LogError(_sb.ToString());
+                        _sb.Length = 0;
+                    }
+                },
+                TaskScheduler.FromCurrentSynchronizationContext());
+
+        private static  readonly StringBuilder _sb = new StringBuilder();
     }
 }

--- a/Assets/Plugins/StreamChat/SampleProject/Scripts/StreamChat.SampleProject.asmdef
+++ b/Assets/Plugins/StreamChat/SampleProject/Scripts/StreamChat.SampleProject.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "StreamChat.SampleProject",
-    "rootNamespace": "StreamChat.SampleProject",
+    "rootNamespace": "",
     "references": [
         "StreamChat.Core",
         "Unity.TextMeshPro",

--- a/Assets/Plugins/StreamChat/Tests/LowLevelClient/Api/MessageApi.cs
+++ b/Assets/Plugins/StreamChat/Tests/LowLevelClient/Api/MessageApi.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Net.Http;
 using NSubstitute;
 using NUnit.Framework;
 using StreamChat.Core.Configs;
@@ -55,11 +56,19 @@ namespace StreamChat.Tests.LowLevelClient.Api
         public void when_client_post_request_expect_valid_uri_and_request_body_in_http_client(EndpointTestCaseBase testCase)
         {
             _lowLevelClient.Connect();
+            
+            var response = new HttpResponseMessage
+            {
+                Content = new StringContent("{\"reaction\": {\"type\": \"like\"}}")
+            };
+
+            _mockHttpClient.PostAsync(Arg.Any<Uri>(), Arg.Any<HttpContent>())
+                .Returns(response);
 
             testCase.ExecuteRequest(_lowLevelClient);
 
             Expression<Predicate<Uri>> ValidateUri = uri => testCase.IsUriValid(uri);
-            Expression<Predicate<string>> ValidateRequestBody = request => testCase.IsRequestBodyValid(request);
+            Expression<Predicate<HttpContent>> ValidateRequestBody = request => testCase.IsRequestBodyValid(request.ReadAsStringAsync().Result);
 
             _mockHttpClient.Received().PostAsync(Arg.Is(ValidateUri), Arg.Is(ValidateRequestBody));
         }
@@ -68,6 +77,14 @@ namespace StreamChat.Tests.LowLevelClient.Api
         public void when_client_delete_request_expect_valid_uri_in_http_client(EndpointTestCaseBase testCase)
         {
             _lowLevelClient.Connect();
+            
+            var response = new HttpResponseMessage
+            {
+                Content = new StringContent("{\"reaction\": {\"type\": \"like\"}}")
+            };
+
+            _mockHttpClient.PostAsync(Arg.Any<Uri>(), Arg.Any<HttpContent>())
+                .Returns(response);
 
             testCase.ExecuteRequest(_lowLevelClient);
 

--- a/Assets/Plugins/StreamChat/Tests/StreamChat.Tests.asmdef
+++ b/Assets/Plugins/StreamChat/Tests/StreamChat.Tests.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "StreamChat.Tests",
-    "rootNamespace": "StreamChat.Tests",
+    "rootNamespace": "",
     "references": [
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:0acc523941302664db1f4e527237feb3",

--- a/StreamChat.Libs.csproj.DotSettings
+++ b/StreamChat.Libs.csproj.DotSettings
@@ -1,4 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cplugins/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cplugins_005Cstreamchat/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cplugins_005Cstreamchat_005Clibs/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cplugins_005Cstreamchat/@EntryIndexedValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cplugins_005Cstreamchat_005Clibs/@EntryIndexedValue">False</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
**Overview:**
Stream uses JWT to authenticate chat users. Tokens need to be provided by your backend solution and can be generated using one of our Stream Chat backend SDKs. Read more [here](https://getstream.io/chat/docs/unity/tokens_and_authentication/?language=unity#token-providers):

**How to use it:**
- `StreamChatClient` has new `IStreamChatClient.ConnectUserAsync(string apiKey, string userId, ITokenProvider tokenProvider, CancellationToken cancellationToken = default)` overload that takes in instance an of `ITokenProvider`
- The `ITokenProvider` requires you to implement its only `Task<string> GetTokenAsync(string userId);` method that will fetch the authorization token for a given user id.	
			
For testing purposes or a simple use case, you can use the `TokenProvider` implementation. It sends a HTTP Get request to a provided URI. It only requires you to provide a URI construction delegate from a given `user_id`.
```
var tokenProvider = StreamChatClient.CreateDefaultTokenProvider(userId => new Uri($"https:your-awesome-page.com/get_token?userId={userId}"));

_client = StreamChatClient.CreateDefaultClient();
await _client.ConnectUserAsync("api-key", userId, tokenProvider);
```
Alternatively, you can provide your own implementation of the `ITokenProvider`:
```
public class YourOwnTokenProvider : ITokenProvider
{
    public Task<string> GetTokenAsync(string userId)
    {
        //Your logic here
    }
}
```
and provide it to the `ConnectUserAsync`:
```
var tokenProvider = new YourOwnTokenProvider();

_client = StreamChatClient.CreateDefaultClient();
await _client.ConnectUserAsync("api-key", userId, tokenProvider);
```