### PR TITLE
Add query channels sort buider

### DIFF
--- a/Assets/Plugins/StreamChat/Core/IStreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/IStreamChatClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using StreamChat.Core.LowLevelClient;
+using StreamChat.Core.QueryBuilders.Sort;
 using StreamChat.Core.Requests;
 using StreamChat.Core.Responses;
 using StreamChat.Core.StatefulModels;
@@ -35,7 +36,7 @@ namespace StreamChat.Core
         /// Event fired when connection state with Stream Chat server has changed
         /// </summary>
         event ConnectionChangeHandler ConnectionStateChanged;
-        
+
         /// <summary>
         /// Channel was deleted
         /// </summary>
@@ -45,12 +46,12 @@ namespace StreamChat.Core
         /// Current connection state
         /// </summary>
         ConnectionState ConnectionState { get; }
-        
+
         /// <summary>
         /// Is client connected. Subscribe to <see cref="Connected"/> to get notified when connection is established
         /// </summary>
         bool IsConnected { get; }
-        
+
         /// <summary>
         /// If true it means that client initiated connection and is waiting for the Stream server to confirm the connection. Subscribe to <see cref="Connected"/> to get notified when connection is established
         /// </summary>
@@ -73,7 +74,7 @@ namespace StreamChat.Core
         /// Next time since startup the client will attempt to reconnect to the Stream Server. 
         /// </summary>
         double? NextReconnectTime { get; }
-        
+
         /// <summary>
         /// Low level client. Use it if you want to bypass the stateful client and execute low level requests directly.
         /// </summary>
@@ -102,7 +103,7 @@ namespace StreamChat.Core
         /// <remarks>https://getstream.io/chat/docs/unity/unity_client_overview/?language=unity#auth-credentials</remarks>
         Task<IStreamLocalUserData> ConnectUserAsync(string apiKey, string userId, string userAuthToken,
             CancellationToken cancellationToken = default);
-        
+
         /// <summary>
         /// 
         /// </summary>
@@ -150,7 +151,19 @@ namespace StreamChat.Core
         /// <param name="limit">How many records to return. Think about it as "records per page"</param>
         /// <param name="offset">How many records to skip. Example: if Limit is 30, the offset for 2nd page is 30, for 3rd page is 60, etc.</param>
         /// <returns></returns>
-        Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters, int limit = 30, int offset = 0);
+        Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters, int limit = 30,
+            int offset = 0);
+
+        /// <summary>
+        /// Query <see cref="IStreamChannel"/> with provided filters
+        /// </summary>
+        /// <param name="filters"></param>
+        /// <param name="sort">Sort object. You can chain multiple sorting fields</param>
+        /// <param name="limit">How many records to return. Think about it as "records per page"</param>
+        /// <param name="offset">How many records to skip. Example: if Limit is 30, the offset for 2nd page is 30, for 3rd page is 60, etc.</param>
+        /// <returns></returns>
+        Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters,
+            ChannelSortObject sort, int limit = 30, int offset = 0);
 
         //StreamTodo: missing descriptions
         Task<IEnumerable<IStreamUser>> QueryUsersAsync(IDictionary<string, object> filters);
@@ -168,7 +181,7 @@ namespace StreamChat.Core
         /// <param name="userRequests"></param>
         /// <returns></returns>
         Task<IEnumerable<IStreamUser>> UpsertUsers(IEnumerable<StreamUserUpsertRequest> userRequests);
-        
+
         /// <summary>
         /// Mute channels with optional duration in milliseconds
         /// </summary>
@@ -194,9 +207,9 @@ namespace StreamChat.Core
         /// <param name="users">Users to mute</param>
         /// <param name="timeoutMinutes">Optional timeout. Without timeout users will stay muted indefinitely</param>
         Task MuteMultipleUsersAsync(IEnumerable<IStreamUser> users, int? timeoutMinutes = default);
-        
+
         Task DisconnectUserAsync();
-        
+
         bool IsLocalUser(IStreamUser messageUser);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/IStreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/IStreamChatClient.cs
@@ -145,27 +145,20 @@ namespace StreamChat.Core
             IDictionary<string, object> optionalCustomData = null);
 
         /// <summary>
-        /// Query <see cref="IStreamChannel"/> with provided filters
+        /// Query <see cref="IStreamChannel"/> with optional: filters, sorting, and pagination
         /// </summary>
-        /// <param name="filters"></param>
-        /// <param name="limit">How many records to return. Think about it as "records per page"</param>
-        /// <param name="offset">How many records to skip. Example: if Limit is 30, the offset for 2nd page is 30, for 3rd page is 60, etc.</param>
-        /// <returns></returns>
-        Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters, int limit = 30,
-            int offset = 0);
+        /// <param name="filters">[Optional] Filters</param>
+        /// <param name="sort">[Optional] Sort object. You can chain multiple sorting fields</param>
+        /// <param name="limit">[Optional] How many records to return. Think about it as "records per page"</param>
+        /// <param name="offset">[Optional] How many records to skip. Example: if Limit is 30, the offset for 2nd page is 30, for 3rd page is 60, etc.</param>
+        Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters = null,
+            ChannelSortObject sort = null, int limit = 30, int offset = 0);
 
         /// <summary>
-        /// Query <see cref="IStreamChannel"/> with provided filters
+        /// Query <see cref="IStreamUser"/>
         /// </summary>
         /// <param name="filters"></param>
-        /// <param name="sort">Sort object. You can chain multiple sorting fields</param>
-        /// <param name="limit">How many records to return. Think about it as "records per page"</param>
-        /// <param name="offset">How many records to skip. Example: if Limit is 30, the offset for 2nd page is 30, for 3rd page is 60, etc.</param>
         /// <returns></returns>
-        Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters,
-            ChannelSortObject sort, int limit = 30, int offset = 0);
-
-        //StreamTodo: missing descriptions
         Task<IEnumerable<IStreamUser>> QueryUsersAsync(IDictionary<string, object> filters);
 
         /// <summary>

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b6aa8fa6e76c4869ad51d381b2d79356
+timeCreated: 1673377936

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f4e109ff931f424b868fbd42ffc8a739
+timeCreated: 1673377944

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSort.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSort.cs
@@ -8,6 +8,10 @@ namespace StreamChat.Core.QueryBuilders.Sort
     /// </summary>
     public static class ChannelSort
     {
+        /// <summary>
+        /// Sort in ascending order meaning from lowest to highest value of the specified field
+        /// </summary>
+        /// <param name="fieldName">Field name to sort by</param>
         public static ChannelSortObject OrderByAscending(ChannelSortFieldName fieldName)
         {
             var instance = new ChannelSortObject();
@@ -15,6 +19,10 @@ namespace StreamChat.Core.QueryBuilders.Sort
             return instance;
         }
 
+        /// <summary>
+        /// Sort in descending order meaning from highest to lowest value of the specified field
+        /// </summary>
+        /// <param name="fieldName">Field name to sort by</param>
         public static ChannelSortObject OrderByDescending(ChannelSortFieldName fieldName)
         {
             var instance = new ChannelSortObject();
@@ -22,9 +30,17 @@ namespace StreamChat.Core.QueryBuilders.Sort
             return instance;
         }
 
+        /// <summary>
+        /// Sort in descending order meaning from highest to lowest value of the specified field
+        /// </summary>
+        /// <param name="fieldName">Field name to sort by</param>
         public static ChannelSortObject ThenByAscending(this ChannelSortObject sort, ChannelSortFieldName fieldName)
             => sort.OrderByAscending(fieldName);
 
+        /// <summary>
+        /// Sort in descending order meaning from highest to lowest value of the specified field
+        /// </summary>
+        /// <param name="fieldName">Field name to sort by</param>
         public static ChannelSortObject ThenByDescending(this ChannelSortObject sort, ChannelSortFieldName fieldName)
             => sort.OrderByDescending(fieldName);
     }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSort.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSort.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Sort
+{
+    /// <summary>
+    /// Factory for creating for <see cref="IStreamChannel"/> query <see cref="IStreamChatClient.QueryChannelsAsync(IDictionary{string,object}, ChannelSortObject, int, int)"/> sort object
+    /// </summary>
+    public static class ChannelSort
+    {
+        public static ChannelSortObject OrderByAscending(ChannelSortFieldName fieldName)
+        {
+            var instance = new ChannelSortObject();
+            instance.OrderByAscending(fieldName);
+            return instance;
+        }
+
+        public static ChannelSortObject OrderByDescending(ChannelSortFieldName fieldName)
+        {
+            var instance = new ChannelSortObject();
+            instance.OrderByDescending(fieldName);
+            return instance;
+        }
+
+        public static ChannelSortObject ThenByAscending(this ChannelSortObject sort, ChannelSortFieldName fieldName)
+            => sort.OrderByAscending(fieldName);
+
+        public static ChannelSortObject ThenByDescending(this ChannelSortObject sort, ChannelSortFieldName fieldName)
+            => sort.OrderByDescending(fieldName);
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSort.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSort.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1db14625d6be408ca1a7b24839287522
+timeCreated: 1673377977

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSortFieldName.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSortFieldName.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Sort
+{
+    /// <summary>
+    /// Field names available for <see cref="IStreamChannel"/> query: <see cref="IStreamChatClient.QueryChannelsAsync(IDictionary{string,object}, ChannelSortObject, int, int)"/>
+    /// </summary>
+    public enum ChannelSortFieldName
+    {
+        LastUpdated,
+        LastMessageAt,
+        UpdatedAt,
+        CreatedAt,
+        MemberCount,
+        UnreadCount,
+        HasUnread
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSortFieldName.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSortFieldName.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 75b2358dd7ae4c9cbbf5041ea0917762
+timeCreated: 1673377977

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSortObject.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSortObject.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Sort
+{
+    /// <summary>
+    /// Sort object for <see cref="IStreamChannel"/> query: <see cref="IStreamChatClient.QueryChannelsAsync(IDictionary{string,object}, ChannelSortObject, int, int)"/>
+    /// </summary>
+    public sealed class ChannelSortObject : QuerySort<ChannelSortObject, ChannelSortFieldName>
+    {
+        protected override ChannelSortObject Instance => this;
+
+        protected override string ToUnderlyingFieldName(ChannelSortFieldName fieldName)
+        {
+            switch (fieldName)
+            {
+                case ChannelSortFieldName.LastUpdated: return "last_updated";
+                case ChannelSortFieldName.LastMessageAt: return "last_message_at";
+                case ChannelSortFieldName.UpdatedAt: return "updated_at";
+                case ChannelSortFieldName.CreatedAt: return "created_at";
+                case ChannelSortFieldName.MemberCount: return "member_count";
+                case ChannelSortFieldName.UnreadCount: return "unread_count ";
+                case ChannelSortFieldName.HasUnread: return "has_unread";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(fieldName), fieldName, null);
+            }
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSortObject.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSortObject.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 455b977f3b1f45a5bb4ddd6216a22218
+timeCreated: 1673377977

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/QuerySort.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/QuerySort.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using StreamChat.Core.InternalDTO.Requests;
+
+namespace StreamChat.Core.QueryBuilders.Sort
+{
+    /// <summary>
+    /// Base class for query sort objects
+    /// </summary>
+    public abstract class QuerySort<TSortType, TFieldType> where TSortType : QuerySort<TSortType, TFieldType>
+    {
+        /// <summary>
+        /// Order by field in an ascending order
+        /// </summary>
+        /// <param name="fieldName"></param>
+        /// <returns></returns>
+        internal TSortType OrderByAscending(TFieldType fieldName)
+        {
+            Instance._order.Add((fieldName, AscendingOrder));
+            return Instance;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="fieldName"></param>
+        /// <returns></returns>
+        internal TSortType OrderByDescending(TFieldType fieldName)
+        {
+            Instance._order.Add((fieldName, DescendingOrder));
+            return Instance;
+        }
+
+        internal List<SortParamRequestInternalDTO> ToSortParams()
+        {
+            var sortParams = new List<SortParamRequestInternalDTO>();
+
+            foreach (var entry in _order)
+            {
+                sortParams.Add(new SortParamRequestInternalDTO
+                {
+                    Direction = entry.Direction,
+                    Field = ToUnderlyingFieldName(entry.Field),
+                });
+            }
+
+            return sortParams;
+        }
+
+        protected abstract TSortType Instance { get; }
+
+        protected abstract string ToUnderlyingFieldName(TFieldType field);
+
+        private const int AscendingOrder = 1;
+        private const int DescendingOrder = -1;
+
+        private readonly List<(TFieldType Field, int Direction)> _order = new List<(TFieldType Field, int Direction)>();
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/QuerySort.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/QuerySort.cs
@@ -30,8 +30,13 @@ namespace StreamChat.Core.QueryBuilders.Sort
             return Instance;
         }
 
-        internal List<SortParamRequestInternalDTO> ToSortParams()
+        internal List<SortParamRequestInternalDTO> ToSortParamRequestList()
         {
+            if (_order.Count == 0)
+            {
+                return null;
+            }
+
             var sortParams = new List<SortParamRequestInternalDTO>();
 
             foreach (var entry in _order)

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/QuerySort.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/QuerySort.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9a4807d1e0e4427fa8298093c77ba571
+timeCreated: 1673377977

--- a/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
@@ -304,9 +304,12 @@ namespace StreamChat.Core
                 Offset = null,
                 Presence = true,
 
-                //StreamTodo: sorting could be controlled in global config,
-                //we definitely don't want to control this per request as this could break data integrity + they can just sort result with LINQ
-                Sort = sort?.ToSortParams(),
+                /*
+                 * StreamTodo: Allowing to sort query can potentially lead to mixed sorting in WatchedChannels
+                 * But there seems no other choice because its too limiting to force only a global sorting for channels
+                 * e.g. user may want to show channels in multiple ways with different sorting which would not work with global only sorting
+                 */
+                Sort = sort?.ToSortParamRequestList(),
                 State = true,
                 Watch = true,
             };

--- a/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
@@ -12,6 +12,7 @@ using StreamChat.Core.LowLevelClient;
 using StreamChat.Core.State;
 using StreamChat.Core.State.Caches;
 using StreamChat.Core.Models;
+using StreamChat.Core.QueryBuilders.Sort;
 using StreamChat.Core.Requests;
 using StreamChat.Core.Responses;
 using StreamChat.Core.StatefulModels;
@@ -58,7 +59,7 @@ namespace StreamChat.Core
         public event ChannelDeleteHandler ChannelDeleted;
 
         public ConnectionState ConnectionState => InternalLowLevelClient.ConnectionState;
-        
+
         public bool IsConnected => InternalLowLevelClient.ConnectionState == ConnectionState.Connected;
         public bool IsConnecting => InternalLowLevelClient.ConnectionState == ConnectionState.Connecting;
 
@@ -69,12 +70,12 @@ namespace StreamChat.Core
         public IReadOnlyList<IStreamChannel> WatchedChannels => _cache.Channels.AllItems;
 
         public double? NextReconnectTime => InternalLowLevelClient.NextReconnectTime;
-        
+
         public IStreamChatLowLevelClient LowLevelClient => InternalLowLevelClient;
 
         /// <inheritdoc cref="StreamChatLowLevelClient.SDKVersion"/>
         public static Version SDKVersion => StreamChatLowLevelClient.SDKVersion;
-        
+
         /// <summary>
         /// Recommended method to create an instance of <see cref="IStreamChatClient"/>
         /// If you wish to create an instance with non default dependencies you can use the <see cref="CreateClientWithCustomDependencies"/>
@@ -84,14 +85,16 @@ namespace StreamChat.Core
         {
             config ??= StreamClientConfig.Default;
             var logs = StreamDependenciesFactory.CreateLogger(config.LogLevel.ToLogLevel());
-            var websocketClient = StreamDependenciesFactory.CreateWebsocketClient(logs, config.LogLevel.IsDebugEnabled());
+            var websocketClient
+                = StreamDependenciesFactory.CreateWebsocketClient(logs, config.LogLevel.IsDebugEnabled());
             var httpClient = StreamDependenciesFactory.CreateHttpClient();
             var serializer = StreamDependenciesFactory.CreateSerializer();
             var timeService = StreamDependenciesFactory.CreateTimeService();
             var applicationInfo = StreamDependenciesFactory.CreateApplicationInfo();
             var gameObjectRunner = StreamDependenciesFactory.CreateChatClientRunner();
 
-            var client = new StreamChatClient(websocketClient, httpClient, serializer, timeService, applicationInfo, logs, config);
+            var client = new StreamChatClient(websocketClient, httpClient, serializer, timeService, applicationInfo,
+                logs, config);
             gameObjectRunner.RunChatInstance(client);
             return client;
         }
@@ -105,7 +108,8 @@ namespace StreamChat.Core
         /// StreamChatClient.CreateDefaultTokenProvider(userId => new Uri($"https:your-awesome-page.com/get_token?userId={userId}"));
         /// </code>
         /// </example>
-        public static ITokenProvider CreateDefaultTokenProvider(TokenProvider.TokenUriHandler urlFactory) => StreamDependenciesFactory.CreateTokenProvider(urlFactory);
+        public static ITokenProvider CreateDefaultTokenProvider(TokenProvider.TokenUriHandler urlFactory)
+            => StreamDependenciesFactory.CreateTokenProvider(urlFactory);
 
         /// <summary>
         /// Create a new instance of <see cref="IStreamChatLowLevelClient"/> with custom provided dependencies.
@@ -113,9 +117,11 @@ namespace StreamChat.Core
         /// Important! Custom created client require calling the <see cref="Update"/> and <see cref="Destroy"/> methods.
         /// </summary>
         public static IStreamChatClient CreateClientWithCustomDependencies(IWebsocketClient websocketClient,
-            IHttpClient httpClient, ISerializer serializer, ITimeService timeService, IApplicationInfo applicationInfo, ILogs logs,
-            IStreamClientConfig config) =>
-            new StreamChatClient(websocketClient, httpClient, serializer, timeService, applicationInfo, logs, config);
+            IHttpClient httpClient, ISerializer serializer, ITimeService timeService, IApplicationInfo applicationInfo,
+            ILogs logs,
+            IStreamClientConfig config)
+            => new StreamChatClient(websocketClient, httpClient, serializer, timeService, applicationInfo, logs,
+                config);
 
         /// <inheritdoc cref="StreamChatLowLevelClient.CreateDeveloperAuthToken"/>
         public static string CreateDeveloperAuthToken(string userId)
@@ -152,15 +158,17 @@ namespace StreamChat.Core
 
             return ConnectUserAsync(new AuthCredentials(apiKey, userId, userAuthToken), cancellationToken);
         }
-        
-        public async Task<IStreamLocalUserData> ConnectUserAsync(string apiKey, string userId, ITokenProvider tokenProvider,
+
+        public async Task<IStreamLocalUserData> ConnectUserAsync(string apiKey, string userId,
+            ITokenProvider tokenProvider,
             CancellationToken cancellationToken = default)
         {
             StreamAsserts.AssertNotNullOrEmpty(apiKey, nameof(apiKey));
             StreamAsserts.AssertNotNullOrEmpty(userId, nameof(userId));
             StreamAsserts.AssertNotNull(tokenProvider, nameof(tokenProvider));
 
-            var ownUserDto = await InternalLowLevelClient.ConnectUserAsync(apiKey, userId, tokenProvider, cancellationToken);
+            var ownUserDto
+                = await InternalLowLevelClient.ConnectUserAsync(apiKey, userId, tokenProvider, cancellationToken);
             return UpdateLocalUser(ownUserDto);
         }
 
@@ -195,7 +203,8 @@ namespace StreamChat.Core
                 requestBodyDto.Data.AdditionalProperties = optionalCustomData?.ToDictionary(x => x.Key, x => x.Value);
             }
 
-            var channelResponseDto = await InternalLowLevelClient.InternalChannelApi.GetOrCreateChannelAsync(channelType,
+            var channelResponseDto = await InternalLowLevelClient.InternalChannelApi.GetOrCreateChannelAsync(
+                channelType,
                 channelId, requestBodyDto);
             return _cache.TryCreateOrUpdate(channelResponseDto);
         }
@@ -262,7 +271,48 @@ namespace StreamChat.Core
                 Watch = true,
             };
 
-            var channelsResponseDto = await InternalLowLevelClient.InternalChannelApi.QueryChannelsAsync(requestBodyDto);
+            var channelsResponseDto
+                = await InternalLowLevelClient.InternalChannelApi.QueryChannelsAsync(requestBodyDto);
+            if (channelsResponseDto.Channels == null || channelsResponseDto.Channels.Count == 0)
+            {
+                return Enumerable.Empty<StreamChannel>();
+            }
+
+            var result = new List<IStreamChannel>();
+            foreach (var channelDto in channelsResponseDto.Channels)
+            {
+                result.Add(_cache.TryCreateOrUpdate(channelDto));
+            }
+
+            return result;
+        }
+
+        public async Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters,
+            ChannelSortObject sort, int limit = 30, int offset = 0)
+        {
+            StreamAsserts.AssertNotNull(filters, nameof(filters));
+            StreamAsserts.AssertWithinRange(limit, 0, 30, nameof(limit));
+            StreamAsserts.AssertGreaterThanOrEqualZero(offset, nameof(offset));
+
+            //StreamTodo: Perhaps MessageLimit and MemberLimit should be configurable
+            var requestBodyDto = new QueryChannelsRequestInternalDTO
+            {
+                FilterConditions = filters.ToDictionary(x => x.Key, x => x.Value),
+                Limit = null,
+                MemberLimit = null,
+                MessageLimit = null,
+                Offset = null,
+                Presence = true,
+
+                //StreamTodo: sorting could be controlled in global config,
+                //we definitely don't want to control this per request as this could break data integrity + they can just sort result with LINQ
+                Sort = sort?.ToSortParams(),
+                State = true,
+                Watch = true,
+            };
+
+            var channelsResponseDto
+                = await InternalLowLevelClient.InternalChannelApi.QueryChannelsAsync(requestBodyDto);
             if (channelsResponseDto.Channels == null || channelsResponseDto.Channels.Count == 0)
             {
                 return Enumerable.Empty<StreamChannel>();
@@ -339,10 +389,11 @@ namespace StreamChat.Core
             //StreamTodo: items could be null
             var requestDtos = userRequests.Select(_ => _.TrySaveToDto()).ToDictionary(_ => _.Id, _ => _);
 
-            var response = await InternalLowLevelClient.InternalUserApi.UpsertManyUsersAsync(new UpdateUsersRequestInternalDTO
-            {
-                Users = requestDtos
-            });
+            var response = await InternalLowLevelClient.InternalUserApi.UpsertManyUsersAsync(
+                new UpdateUsersRequestInternalDTO
+                {
+                    Users = requestDtos
+                });
 
             var result = new List<IStreamUser>();
             foreach (var userDto in response.Users.Values)
@@ -363,11 +414,12 @@ namespace StreamChat.Core
                 throw new ArgumentException($"{nameof(channels)} is empty");
             }
 
-            var response = await InternalLowLevelClient.InternalChannelApi.MuteChannelAsync(new MuteChannelRequestInternalDTO
-            {
-                ChannelCids = channelCids,
-                Expiration = milliseconds
-            });
+            var response = await InternalLowLevelClient.InternalChannelApi.MuteChannelAsync(
+                new MuteChannelRequestInternalDTO
+                {
+                    ChannelCids = channelCids,
+                    Expiration = milliseconds
+                });
 
             UpdateLocalUser(response.OwnUser);
         }
@@ -413,11 +465,12 @@ namespace StreamChat.Core
         {
             StreamAsserts.AssertNotNullOrEmpty(users, nameof(users));
 
-            var responseDto = await InternalLowLevelClient.InternalModerationApi.MuteUserAsync(new MuteUserRequestInternalDTO
-            {
-                TargetIds = users.Select(_ => _.Id).ToList(),
-                Timeout = timeoutMinutes
-            });
+            var responseDto = await InternalLowLevelClient.InternalModerationApi.MuteUserAsync(
+                new MuteUserRequestInternalDTO
+                {
+                    TargetIds = users.Select(_ => _.Id).ToList(),
+                    Timeout = timeoutMinutes
+                });
 
             UpdateLocalUser(responseDto.OwnUser);
         }
@@ -493,7 +546,7 @@ namespace StreamChat.Core
 
             return GetOrCreateChannelWithIdAsync(channel.Type, channel.Id);
         }
-        
+
         private readonly ILogs _logs;
         private readonly ITimeService _timeService;
         private readonly ICache _cache;
@@ -522,7 +575,7 @@ namespace StreamChat.Core
         /// </example>
         /// In case you want to inject custom dependencies into the chat client you can use the <see cref="CreateClientWithCustomDependencies"/>
         /// </summary>
-        private StreamChatClient(IWebsocketClient websocketClient, IHttpClient httpClient, ISerializer serializer, 
+        private StreamChatClient(IWebsocketClient websocketClient, IHttpClient httpClient, ISerializer serializer,
             ITimeService timeService, IApplicationInfo applicationInfo, ILogs logs, IStreamClientConfig config)
         {
             _timeService = timeService ?? throw new ArgumentNullException(nameof(timeService));

--- a/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
@@ -245,59 +245,17 @@ namespace StreamChat.Core
             return _cache.TryCreateOrUpdate(channelResponseDto);
         }
 
-        //StreamTodo: Filter object that contains a factory
-        //StreamTodo: implement pagination + sorting seems useful for paginated query results
-        public async Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters,
-            int limit = 30, int offset = 0)
+        //StreamTodo: Filter object that contains a factory syntax supported builder
+        public async Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters = null,
+            ChannelSortObject sort = null, int limit = 30, int offset = 0)
         {
-            StreamAsserts.AssertNotNull(filters, nameof(filters));
             StreamAsserts.AssertWithinRange(limit, 0, 30, nameof(limit));
             StreamAsserts.AssertGreaterThanOrEqualZero(offset, nameof(offset));
 
             //StreamTodo: Perhaps MessageLimit and MemberLimit should be configurable
             var requestBodyDto = new QueryChannelsRequestInternalDTO
             {
-                FilterConditions = filters.ToDictionary(x => x.Key, x => x.Value),
-                Limit = null,
-                MemberLimit = null,
-                MessageLimit = null,
-                Offset = null,
-                Presence = true,
-
-                //StreamTodo: sorting could be controlled in global config,
-                //we definitely don't want to control this per request as this could break data integrity + they can just sort result with LINQ
-                Sort = null,
-                State = true,
-                Watch = true,
-            };
-
-            var channelsResponseDto
-                = await InternalLowLevelClient.InternalChannelApi.QueryChannelsAsync(requestBodyDto);
-            if (channelsResponseDto.Channels == null || channelsResponseDto.Channels.Count == 0)
-            {
-                return Enumerable.Empty<StreamChannel>();
-            }
-
-            var result = new List<IStreamChannel>();
-            foreach (var channelDto in channelsResponseDto.Channels)
-            {
-                result.Add(_cache.TryCreateOrUpdate(channelDto));
-            }
-
-            return result;
-        }
-
-        public async Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters,
-            ChannelSortObject sort, int limit = 30, int offset = 0)
-        {
-            StreamAsserts.AssertNotNull(filters, nameof(filters));
-            StreamAsserts.AssertWithinRange(limit, 0, 30, nameof(limit));
-            StreamAsserts.AssertGreaterThanOrEqualZero(offset, nameof(offset));
-
-            //StreamTodo: Perhaps MessageLimit and MemberLimit should be configurable
-            var requestBodyDto = new QueryChannelsRequestInternalDTO
-            {
-                FilterConditions = filters.ToDictionary(x => x.Key, x => x.Value),
+                FilterConditions = filters?.ToDictionary(x => x.Key, x => x.Value),
                 Limit = null,
                 MemberLimit = null,
                 MessageLimit = null,

--- a/Assets/Plugins/StreamChat/Samples/ChannelsCodeSamples.cs
+++ b/Assets/Plugins/StreamChat/Samples/ChannelsCodeSamples.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using StreamChat.Core;
 using StreamChat.Core.Models;
+using StreamChat.Core.QueryBuilders.Sort;
 using StreamChat.Core.StatefulModels;
 using UnityEngine;
 
@@ -138,19 +139,21 @@ namespace StreamChat.Samples
         public async Task WatchingMultipleChannels()
         {
             var localUser = Client.LocalUserData.User;
-
-// Get channels where local user is a member of
-            var channels = await Client.QueryChannelsAsync(new Dictionary<string, object>
+            
+            var filter = new Dictionary<string, object>
             {
                 {
+                    // Get channels where local user is a member of
                     "members", new Dictionary<string, object>
                     {
                         { "$in", new[] { localUser.Id } }
                     }
                 }
-            });
+            };
 
-// Get all currently watched channels
+            var channels = await Client.QueryChannelsAsync(filter);
+
+            // After query is done - loop channels and subscribe to events 
             foreach (var channel in channels)
             {
                 // Access properties
@@ -167,6 +170,53 @@ namespace StreamChat.Samples
                 channel.ReactionUpdated += OnReactionUpdated;
                 channel.ReactionRemoved += OnReactionRemoved;
             }
+        }
+
+        /// <summary>
+        /// https://getstream.io/chat/docs/unity/watch_channel/?language=unity#watching-multiple-channels
+        /// </summary>
+        public async Task WatchingMultipleChannels2()
+        {
+            var localUser = Client.LocalUserData.User;
+
+            var filter = new Dictionary<string, object>
+            {
+                {
+                    // Get channels where local user is a member of
+                    "members", new Dictionary<string, object>
+                    {
+                        { "$in", new[] { localUser.Id } }
+                    }
+                }
+            };
+
+            // You can also sort by various fields
+            var sort = ChannelSort.OrderByDescending(ChannelSortFieldName.LastMessageAt);
+            var channels = await Client.QueryChannelsAsync(filter, sort);
+        }
+        
+        /// <summary>
+        /// https://getstream.io/chat/docs/unity/watch_channel/?language=unity#watching-multiple-channels
+        /// </summary>
+        public async Task WatchingMultipleChannels3()
+        {
+            var localUser = Client.LocalUserData.User;
+
+            var filter = new Dictionary<string, object>
+            {
+                {
+                    // Get channels where local user is a member of
+                    "members", new Dictionary<string, object>
+                    {
+                        { "$in", new[] { localUser.Id } }
+                    }
+                }
+            };
+
+            // You can sort by multiple fields and chain as many ThenByDescending as you need
+            var sort = ChannelSort.OrderByDescending(ChannelSortFieldName.MemberCount).ThenByDescending(ChannelSortFieldName.CreatedAt);
+            
+            var channels = await Client.QueryChannelsAsync(filter, sort);
         }
 
         /// <summary>

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/BaseStateIntegrationTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/BaseStateIntegrationTests.cs
@@ -94,7 +94,7 @@ namespace StreamChat.Tests.StatefulClient
         /// <summary>
         /// Use this if state update depends on receiving WS event that might come after the REST call was completed
         /// </summary>
-        protected static async Task WaitWhileConditionTrue(Func<bool> condition, int maxIterations = 150)
+        protected static async Task WaitWhileConditionTrue(Func<bool> condition, int maxIterations = 500)
         {
             if (!condition())
             {
@@ -110,7 +110,7 @@ namespace StreamChat.Tests.StatefulClient
             }
         }
         
-        protected static async Task WaitWhileConditionFalse(Func<bool> condition, int maxIterations = 150)
+        protected static async Task WaitWhileConditionFalse(Func<bool> condition, int maxIterations = 500)
         {
             if (condition())
             {

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQuerySortTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQuerySortTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿#if STREAM_TESTS_ENABLED
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -92,3 +93,4 @@ namespace StreamChat.Tests.StatefulClient
         }
     }
 }
+#endif

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQuerySortTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQuerySortTests.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using StreamChat.Core;
+using StreamChat.Core.QueryBuilders.Sort;
+using UnityEngine.TestTools;
+
+namespace StreamChat.Tests.StatefulClient
+{
+    /// <summary>
+    /// Tests for <see cref="IStreamChatClient.QueryChannelsAsync(System.Collections.Generic.IDictionary{string,object},ChannelSortObject,int,int)"/>
+    /// </summary>
+    internal class ChannelsQuerySortTests : BaseStateIntegrationTests
+    {
+        [UnityTest]
+        public IEnumerator When_order_channels_by_created_at_desc_expect_valid_order()
+            => ConnectAndExecute(When_order_channels_by_created_at_desc_expect_valid_order_Async);
+
+        private async Task When_order_channels_by_created_at_desc_expect_valid_order_Async()
+        {
+            var channel = await CreateUniqueTempChannelAsync();
+            var channel2 = await CreateUniqueTempChannelAsync();
+            var channel3 = await CreateUniqueTempChannelAsync();
+            var channel4 = await CreateUniqueTempChannelAsync();
+
+            var filter = new Dictionary<string, object>
+            {
+                {
+                    "cid", new Dictionary<string, object>
+                    {
+                        { "$in", new List<string> { channel.Cid, channel2.Cid, channel3.Cid, channel4.Cid } }
+                    }
+                }
+            };
+
+            var sort = ChannelSort.OrderByDescending(ChannelSortFieldName.CreatedAt);
+
+            var channels = await Client.QueryChannelsAsync(filter, sort);
+            Assert.NotNull(channels);
+            Assert.AreEqual(4, channels.Count());
+            Assert.IsTrue(channels.SequenceEqual(new[] { channel4, channel3, channel2, channel }));
+        }
+
+        [UnityTest]
+        public IEnumerator When_order_channels_by_two_fields_expect_valid_order()
+            => ConnectAndExecute(When_order_channels_by_two_fields_expect_valid_order_Async);
+
+        private async Task When_order_channels_by_two_fields_expect_valid_order_Async()
+        {
+            /*
+             * Scenario:
+             *
+             * member counts:
+             * channel1 -> 2
+             * channel3 -> 2
+             * channel2 -> 1
+             * channel4 -> 1
+             *
+             * order by member_count DESC then by created_at DESC should result in:
+             *  channel3 -> channel1 -> channel4 -> channel2
+             */
+            var channel1 = await CreateUniqueTempChannelAsync();
+            var channel2 = await CreateUniqueTempChannelAsync();
+            var channel3 = await CreateUniqueTempChannelAsync();
+            var channel4 = await CreateUniqueTempChannelAsync();
+
+            await channel1.AddMembersAsync(TestAdminId, TestUserId);
+            await channel3.AddMembersAsync(TestAdminId, TestUserId);
+            
+            await channel2.AddMembersAsync(TestAdminId);
+            await channel4.AddMembersAsync(TestAdminId);
+
+            var filter = new Dictionary<string, object>
+            {
+                {
+                    "cid", new Dictionary<string, object>
+                    {
+                        { "$in", new List<string> { channel1.Cid, channel2.Cid, channel3.Cid, channel4.Cid } }
+                    }
+                }
+            };
+
+            var sort = ChannelSort.OrderByDescending(ChannelSortFieldName.MemberCount)
+                .ThenByDescending(ChannelSortFieldName.CreatedAt);
+
+            var channels = await Client.QueryChannelsAsync(filter, sort);
+            Assert.NotNull(channels);
+            Assert.AreEqual(4, channels.Count());
+            Assert.IsTrue(channels.SequenceEqual(new[] { channel3, channel1, channel4, channel2 }));
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQuerySortTests.cs.meta
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQuerySortTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4e54817300a24b5b91a94de937e8b9ce
+timeCreated: 1673375493

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsTests.cs
@@ -474,6 +474,20 @@ namespace StreamChat.Tests.StatefulClient
             Assert.NotNull(firstMember);
             Assert.NotNull(lastMember);
         }
+        
+        [UnityTest]
+        public IEnumerator When_query_channels_with_no_parameters_expect_no_errors()
+            => ConnectAndExecute(When_query_channels_with_no_parameters_expect_no_errors_Async);
+
+        private async Task When_query_channels_with_no_parameters_expect_no_errors_Async()
+        {
+            var channel = await CreateUniqueTempChannelAsync();
+            var channel2 = await CreateUniqueTempChannelAsync();
+
+            var channels = await Client.QueryChannelsAsync();
+            Assert.NotNull(channels);
+            Assert.AreNotEqual(0, channels.Count());
+        }
     }
 }
 

--- a/StreamChat.Tests.csproj.DotSettings
+++ b/StreamChat.Tests.csproj.DotSettings
@@ -1,4 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cplugins/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cplugins_005Cstreamchat/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cplugins_005Cstreamchat_005Ctests/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cplugins_005Cstreamchat/@EntryIndexedValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cplugins_005Cstreamchat_005Ctests/@EntryIndexedValue">False</s:Boolean></wpf:ResourceDictionary>

--- a/StreamChat.Tests.csproj.DotSettings
+++ b/StreamChat.Tests.csproj.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cplugins/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cplugins_005Cstreamchat/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cplugins_005Cstreamchat_005Ctests/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
You can now pass an optional sort object to the `IStreamChatClient.QueryChannelsAsync` method:
```
var sort = ChannelSort.OrderByDescending(ChannelSortFieldName.LastMessageAt);
var channels = await Client.QueryChannelsAsync(filter, sort);
```
You can also sort by multiple fields:
```
var sort = ChannelSort.OrderByDescending(ChannelSortFieldName.MemberCount).ThenByDescending(ChannelSortFieldName.CreatedAt);
var channels = await Client.QueryChannelsAsync(filter, sort);
```
This works similarly to .NET LINQ or SQL sorting meaning that records would be first sorted by `MemberCount` and every groups with equal `MemberCount` would be then sorted by `CreatedAt` field