### PR TITLE
Improve integration tests stability

### DIFF
--- a/Assets/Plugins/StreamChat/Core/Exceptions/StreamApiException.cs
+++ b/Assets/Plugins/StreamChat/Core/Exceptions/StreamApiException.cs
@@ -10,6 +10,8 @@ namespace StreamChat.Core.Exceptions
     /// </summary>
     public class StreamApiException : Exception
     {
+        public const int RateLimitErrorErrorCode = 429;
+        
         public int? StatusCode { get; }
         public int? Code { get;  }
         public string Duration { get;  }

--- a/Assets/Plugins/StreamChat/Tests/LowLevelClient/Integration/BaseIntegrationTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/LowLevelClient/Integration/BaseIntegrationTests.cs
@@ -63,7 +63,6 @@ namespace StreamChat.Tests.LowLevelClient.Integration
 
             yield return createChannelTask.RunAsIEnumerator(response =>
             {
-                _tempChannelsToDelete.Add((response.Channel.Type, response.Channel.Id));
                 onChannelReturned?.Invoke(response);
             });
         }
@@ -75,6 +74,24 @@ namespace StreamChat.Tests.LowLevelClient.Integration
             ChannelGetOrCreateRequest channelGetOrCreateRequest)
         {
             var channelId = "random-channel-" + Guid.NewGuid();
+
+            var channelsResponse = await LowLevelClient.ChannelApi.QueryChannelsAsync(new QueryChannelsRequest()
+            {
+                FilterConditions = new Dictionary<string, object>
+                {
+                    {
+                        "id", new Dictionary<string, object>
+                        {
+                            { "$in", new[] { channelId } }
+                        }
+                    }
+                }
+            });
+
+            if (channelsResponse.Channels != null && channelsResponse.Channels.Count > 0)
+            {
+                Debug.LogError($"Channel with id {channelId} already exists!");
+            }
 
             var channelState
                 = await LowLevelClient.ChannelApi.GetOrCreateChannelAsync(channelType, channelId, channelGetOrCreateRequest);

--- a/Assets/Plugins/StreamChat/Tests/LowLevelClient/Integration/ChannelApiIntegrationTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/LowLevelClient/Integration/ChannelApiIntegrationTests.cs
@@ -115,6 +115,7 @@ namespace StreamChat.Tests.LowLevelClient.Integration
             {
                 Assert.AreEqual(channelId, response.Channel.Id);
                 Assert.AreEqual(channelType, response.Channel.Type);
+                RemoveTempChannelFromDeleteList(response.Channel.Cid);
             });
         }
 
@@ -350,7 +351,7 @@ namespace StreamChat.Tests.LowLevelClient.Integration
 
             var deleteChannelTask2 = LowLevelClient.ChannelApi.DeleteChannelAsync(channelType, channelId, isHardDelete: false);
 
-            deleteChannelTask2.RunAsIEnumerator(onFaulted: exception =>
+            yield return deleteChannelTask2.RunAsIEnumerator(onFaulted: exception =>
             {
                 Assert.AreEqual(((StreamApiException)exception).StatusCode, 404);
             });
@@ -364,7 +365,6 @@ namespace StreamChat.Tests.LowLevelClient.Integration
             var channelType = "messaging";
 
             var channelsCIdsToDelete = new List<string>();
-
             yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(),
                 state => channelsCIdsToDelete.Add(state.Channel.Cid));
             yield return CreateTempUniqueChannel(channelType, new ChannelGetOrCreateRequest(),
@@ -385,6 +385,7 @@ namespace StreamChat.Tests.LowLevelClient.Integration
                 foreach (var cidToDelete in channelsCIdsToDelete)
                 {
                     Assert.IsTrue(response.Result.Any(_ => _.Key == cidToDelete));
+                    RemoveTempChannelFromDeleteList(cidToDelete);
                 }
             });
         }

--- a/Assets/Plugins/StreamChat/Tests/LowLevelClient/Integration/MessagesApiIntegrationTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/LowLevelClient/Integration/MessagesApiIntegrationTests.cs
@@ -498,6 +498,11 @@ namespace StreamChat.Tests.LowLevelClient.Integration
                     injectedMessageIds.Add(messageResponse.Message.Id);
                 }
             }
+
+            if (injectedMessageIds.Count != 3)
+            {
+                Debug.LogError("Failed to inject search phrase into 3 messages");
+            }
             
             Assert.AreEqual(3, injectedMessageIds.Count);
 
@@ -546,6 +551,16 @@ namespace StreamChat.Tests.LowLevelClient.Integration
             
             Assert.NotNull(response);
             Assert.NotNull(response.Results);
+
+            if (response.Results.Count > 3)
+            {
+                Debug.Log("Error: Search returned more results than expected. Listing found messages:");
+                foreach (var message in response.Results)
+                {
+                    Debug.Log(message.Message.Text);
+                }
+            }
+
             Assert.AreEqual(3, response.Results.Count);
 
             foreach (var injectedPhrase in phrasesToInject)

--- a/Assets/Plugins/StreamChat/Tests/LowLevelClient/Integration/MessagesApiIntegrationTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/LowLevelClient/Integration/MessagesApiIntegrationTests.cs
@@ -530,13 +530,22 @@ namespace StreamChat.Tests.LowLevelClient.Integration
                             }
                         }
                     },
+                    
+                    Sort = new List<SortParamRequest>
+                    {
+                        new SortParamRequest
+                        {
+                            Field = "created_at",
+                            Direction = -1
+                        }
+                    },
 
                     //search phrase
                     Query = "bengal"
                 });
             
                 // Due to data propagation the results may not be instant
-                if (response.Results.Count != 3)
+                if (response.Results.Count(r => r.Message.Channel.Cid == channelState.Channel.Cid) != 3)
                 {
                     for (int i = 0; i < 50; i++)
                     {
@@ -552,16 +561,16 @@ namespace StreamChat.Tests.LowLevelClient.Integration
             Assert.NotNull(response);
             Assert.NotNull(response.Results);
 
-            if (response.Results.Count > 3)
+            if (response.Results.Count(r => r.Message.Channel.Cid == channelState.Channel.Cid) > 3)
             {
                 Debug.Log("Error: Search returned more results than expected. Listing found messages:");
                 foreach (var message in response.Results)
                 {
-                    Debug.Log(message.Message.Text);
+                    Debug.Log($"{message.Message.Channel.Cid} - {message.Message.Text}");
                 }
             }
 
-            Assert.AreEqual(3, response.Results.Count);
+            Assert.AreEqual(3, response.Results.Count(r => r.Message.Channel.Cid == channelState.Channel.Cid));
 
             foreach (var injectedPhrase in phrasesToInject)
             {

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/BaseStateIntegrationTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/BaseStateIntegrationTests.cs
@@ -174,6 +174,8 @@ namespace StreamChat.Tests.StatefulClient
                 {
                     await Task.Delay(500);
                 }
+                Debug.Log($"Try {nameof(DeleteTempChannelsAsync)} again due to exception:  " + streamApiException);
+
                 await Client.DeleteMultipleChannelsAsync(_tempChannels, isHardDelete: true);
             }
 

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/BaseStateIntegrationTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/BaseStateIntegrationTests.cs
@@ -12,20 +12,27 @@ using StreamChat.Core.StatefulModels;
 using StreamChat.EditorTools;
 using StreamChat.Libs.Auth;
 using UnityEngine;
-using UnityEngine.TestTools;
 
 namespace StreamChat.Tests.StatefulClient
 {
     internal abstract class BaseStateIntegrationTests
     {
-        [SetUp]
-        public void Up() => InitClient();
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
+        [OneTimeSetUp]
+        public void OneTimeUp()
         {
-            yield return DeleteTempChannelsAsync().RunAsIEnumerator();
-            yield return Client.DisconnectUserAsync().RunAsIEnumerator();
+            Debug.Log("------------ Up");
+            InitClient();
+        }
+
+        [OneTimeTearDown]
+        public async void OneTimeTearDown()
+        {
+            Debug.Log("------------ TearDown");
+            
+            await DeleteTempChannelsAsync();
+            
+            await Client.DisconnectUserAsync();
+            
             Client.Dispose();
             Client = null;
         }
@@ -51,6 +58,11 @@ namespace StreamChat.Tests.StatefulClient
 
         protected async Task ConnectUserAsync(UserLevel level = UserLevel.Admin)
         {
+            if (Client.IsConnected)
+            {
+                return;
+            }
+            
             var userCredentials = GetUserAuthCredentials(level);
             var connectTask = Client.ConnectUserAsync(userCredentials);
             while (!connectTask.IsCompleted)

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsTests.cs
@@ -296,6 +296,9 @@ namespace StreamChat.Tests.StatefulClient
                 }
             });
 
+            await WaitWhileConditionFalse(
+                () => new[] { "owned_dogs", "breakfast" }.All(channel.CustomData.ContainsKey), 1000);
+
             var ownedDogs = channel.CustomData.Get<int>("owned_dogs");
             var breakfast = channel.CustomData.Get<List<string>>("breakfast");
 
@@ -474,7 +477,7 @@ namespace StreamChat.Tests.StatefulClient
             Assert.NotNull(firstMember);
             Assert.NotNull(lastMember);
         }
-        
+
         [UnityTest]
         public IEnumerator When_query_channels_with_no_parameters_expect_no_errors()
             => ConnectAndExecute(When_query_channels_with_no_parameters_expect_no_errors_Async);

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsTests.cs
@@ -110,6 +110,9 @@ namespace StreamChat.Tests.StatefulClient
 
             await channel.MuteChannelAsync();
 
+            // Wait for data to propagate
+            await WaitWhileConditionTrue(() => Client.LocalUserData.ChannelMutes.Count == 0);
+
             Assert.IsNotEmpty(Client.LocalUserData.ChannelMutes);
 
             var channelMute = Client.LocalUserData.ChannelMutes.FirstOrDefault(m => m.Channel == channel);

--- a/Assets/Plugins/StreamChat/Tests/UnityTestUtils.cs
+++ b/Assets/Plugins/StreamChat/Tests/UnityTestUtils.cs
@@ -24,21 +24,14 @@ namespace StreamChat.Tests
 
             if (task.IsFaulted)
             {
+                var ex = UnwrapAggregateException(task.Exception);
                 if (onFaulted != null)
                 {
-                    onFaulted(task.Exception);
+                    onFaulted(ex);
                     yield break;
                 }
-                else
-                {
-                    if (task.Exception is AggregateException aggregateException &&
-                        aggregateException.InnerExceptions.Count == 1)
-                    {
-                        throw task.Exception.InnerException;
-                    }
-
-                    throw task.Exception;
-                }
+                
+                throw ex;
             }
 
             onSuccess?.Invoke(task.Result);
@@ -55,19 +48,14 @@ namespace StreamChat.Tests
 
             if (task.IsFaulted)
             {
+                var ex = UnwrapAggregateException(task.Exception);
                 if (onFaulted != null)
                 {
-                    onFaulted(task.Exception);
+                    onFaulted(ex);
                     yield break;
                 }
                 
-                if (task.Exception is AggregateException aggregateException &&
-                    aggregateException.InnerExceptions.Count == 1)
-                {
-                    throw task.Exception.InnerException;
-                }
-
-                throw task.Exception;
+                throw ex;
             }
 
             onSuccess?.Invoke();
@@ -84,19 +72,14 @@ namespace StreamChat.Tests
 
             if (task.IsFaulted)
             {
+                var ex = UnwrapAggregateException(task.Exception);
                 if (onFaulted != null)
                 {
-                    onFaulted(task.Exception);
+                    onFaulted(ex);
                     yield break;
                 }
                 
-                if (task.Exception is AggregateException aggregateException &&
-                    aggregateException.InnerExceptions.Count == 1)
-                {
-                    throw task.Exception.InnerException;
-                }
-
-                throw task.Exception;
+                throw ex;
             }
 
             onSuccess?.Invoke();
@@ -167,6 +150,17 @@ namespace StreamChat.Tests
             {
                 yield return null;
             }
+        }
+        
+        private static Exception UnwrapAggregateException(Exception exception)
+        {
+            if (exception is AggregateException aggregateException &&
+                aggregateException.InnerExceptions.Count == 1)
+            {
+                return aggregateException.InnerExceptions[0];
+            }
+
+            return exception;
         }
     }
 }


### PR DESCRIPTION
- Add retry after delay for temp channels delete when "too many requests" error was returned +
- add a small delay to `When_unset_channel_custom_data_expect_no_data_on_channel_object` to fix minor delay related to data propagation