### PR TITLE
Created syntax based query filters builder

### DIFF
--- a/Assets/Plugins/StreamChat/Core/IStreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/IStreamChatClient.cs
@@ -67,7 +67,7 @@ namespace StreamChat.Core
 
         /// <summary>
         /// Watched channels receive updates on all users activity like new messages, reactions, etc.
-        /// Use <see cref="GetOrCreateChannelWithIdAsync"/> and <see cref="QueryChannelsAsync(System.Collections.Generic.IDictionary{string,object},StreamChat.Core.QueryBuilders.Sort.ChannelSortObject,int,int)"/> to watch channels
+        /// Use <see cref="GetOrCreateChannelWithIdAsync"/> and <see cref="QueryChannelsAsync"/> to watch channels
         /// </summary>
         IReadOnlyList<IStreamChannel> WatchedChannels { get; }
 
@@ -152,7 +152,9 @@ namespace StreamChat.Core
         /// <param name="sort">[Optional] Sort object. You can chain multiple sorting fields</param>
         /// <param name="limit">[Optional] How many records to return. Think about it as "records per page"</param>
         /// <param name="offset">[Optional] How many records to skip. Example: if Limit is 30, the offset for 2nd page is 30, for 3rd page is 60, etc.</param>
-        Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters = null,
+        [Obsolete("This method will be removed in the future. Please use the other overload method that uses " +
+                  nameof(IFieldFilterRule) + " type filters")]
+        Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters,
             ChannelSortObject sort = null, int limit = 30, int offset = 0);
         
         /// <summary>
@@ -162,7 +164,7 @@ namespace StreamChat.Core
         /// <param name="sort">[Optional] Sort object. You can chain multiple sorting fields</param>
         /// <param name="limit">[Optional] How many records to return. Think about it as "records per page"</param>
         /// <param name="offset">[Optional] How many records to skip. Example: if Limit is 30, the offset for 2nd page is 30, for 3rd page is 60, etc.</param>
-        Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IEnumerable<IFieldFilterRule> filters,
+        Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IEnumerable<IFieldFilterRule> filters = null,
             ChannelSortObject sort = null, int limit = 30, int offset = 0);
 
         /// <summary>

--- a/Assets/Plugins/StreamChat/Core/IStreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/IStreamChatClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using StreamChat.Core.LowLevelClient;
+using StreamChat.Core.QueryBuilders.Filters;
 using StreamChat.Core.QueryBuilders.Sort;
 using StreamChat.Core.Requests;
 using StreamChat.Core.Responses;
@@ -66,7 +67,7 @@ namespace StreamChat.Core
 
         /// <summary>
         /// Watched channels receive updates on all users activity like new messages, reactions, etc.
-        /// Use <see cref="GetOrCreateChannelWithIdAsync"/> and <see cref="QueryChannelsAsync"/> to watch channels
+        /// Use <see cref="GetOrCreateChannelWithIdAsync"/> and <see cref="QueryChannelsAsync(System.Collections.Generic.IDictionary{string,object},StreamChat.Core.QueryBuilders.Sort.ChannelSortObject,int,int)"/> to watch channels
         /// </summary>
         IReadOnlyList<IStreamChannel> WatchedChannels { get; }
 
@@ -152,6 +153,16 @@ namespace StreamChat.Core
         /// <param name="limit">[Optional] How many records to return. Think about it as "records per page"</param>
         /// <param name="offset">[Optional] How many records to skip. Example: if Limit is 30, the offset for 2nd page is 30, for 3rd page is 60, etc.</param>
         Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters = null,
+            ChannelSortObject sort = null, int limit = 30, int offset = 0);
+        
+        /// <summary>
+        /// Query <see cref="IStreamChannel"/> with optional: filters, sorting, and pagination
+        /// </summary>
+        /// <param name="filters">[Optional] Filters</param>
+        /// <param name="sort">[Optional] Sort object. You can chain multiple sorting fields</param>
+        /// <param name="limit">[Optional] How many records to return. Think about it as "records per page"</param>
+        /// <param name="offset">[Optional] How many records to skip. Example: if Limit is 30, the offset for 2nd page is 30, for 3rd page is 60, etc.</param>
+        Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IEnumerable<IFieldFilterRule> filters,
             ChannelSortObject sort = null, int limit = 30, int offset = 0);
 
         /// <summary>

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 094564a7e6814034b0ce985d4c206e9f
+timeCreated: 1673973849

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/BaseFieldToFilter.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/BaseFieldToFilter.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
 
 namespace StreamChat.Core.QueryBuilders.Filters
 {
@@ -18,6 +16,9 @@ namespace StreamChat.Core.QueryBuilders.Filters
         protected FieldFilterRule InternalEqualsTo(string value)
             => new FieldFilterRule(FieldName, QueryOperatorType.Equals, value);
         
+        protected FieldFilterRule InternalEqualsTo(int value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.Equals, value);
+        
         protected FieldFilterRule InternalEqualsTo(DateTime value)
             => new FieldFilterRule(FieldName, QueryOperatorType.Equals, value);
         
@@ -27,11 +28,41 @@ namespace StreamChat.Core.QueryBuilders.Filters
         protected FieldFilterRule InternalIn(IEnumerable<string> values)
             => new FieldFilterRule(FieldName, QueryOperatorType.In, values);
         
-        protected FieldFilterRule InternalLessThanOrEquals(DateTime dateTime)
-            => new FieldFilterRule(FieldName, QueryOperatorType.LessThanOrEquals, dateTime);
+        protected FieldFilterRule InternalGreaterThan(DateTime value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.GreaterThan, value);
         
-        protected FieldFilterRule InternalLessThanOrEquals(DateTimeOffset dateTimeOffset)
-            => new FieldFilterRule(FieldName, QueryOperatorType.LessThanOrEquals, dateTimeOffset);
+        protected FieldFilterRule InternalGreaterThan(DateTimeOffset value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.GreaterThan, value);
+        
+        protected FieldFilterRule InternalGreaterThan(int value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.GreaterThan, value);
+        
+        protected FieldFilterRule InternalGreaterThanOrEquals(DateTime dateTime)
+            => new FieldFilterRule(FieldName, QueryOperatorType.GreaterThanOrEquals, dateTime);
+        
+        protected FieldFilterRule InternalGreaterThanOrEquals(DateTimeOffset value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.GreaterThanOrEquals, value);
+        
+        protected FieldFilterRule InternalGreaterThanOrEquals(int value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.GreaterThanOrEquals, value);
+        
+        protected FieldFilterRule InternalLessThan(DateTime value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.LessThan, value);
+        
+        protected FieldFilterRule InternalLessThan(DateTimeOffset value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.LessThan, value);
+        
+        protected FieldFilterRule InternalLessThan(int value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.LessThan, value);
+        
+        protected FieldFilterRule InternalLessThanOrEquals(DateTime value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.LessThanOrEquals, value);
+        
+        protected FieldFilterRule InternalLessThanOrEquals(DateTimeOffset value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.LessThanOrEquals, value);
+        
+        protected FieldFilterRule InternalLessThanOrEquals(int value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.LessThanOrEquals, value);
 
         protected FieldFilterRule InternalAutocomplete(string value)
             => new FieldFilterRule(FieldName, QueryOperatorType.Autocomplete, value);

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/BaseFieldToFilter.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/BaseFieldToFilter.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace StreamChat.Core.QueryBuilders.Filters
+{
+    /// <summary>
+    /// Base class for field filters
+    /// </summary>
+    public abstract class BaseFieldToFilter : IFieldToFilter
+    {
+        public abstract string FieldName { get; }
+
+        protected FieldFilterRule InternalEqualsTo(bool value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.Equals, value);
+        
+        protected FieldFilterRule InternalEqualsTo(string value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.Equals, value);
+        
+        protected FieldFilterRule InternalEqualsTo(DateTime value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.Equals, value);
+        
+        protected FieldFilterRule InternalEqualsTo(DateTimeOffset value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.Equals, value);
+
+        protected FieldFilterRule InternalIn(IEnumerable<string> values)
+            => new FieldFilterRule(FieldName, QueryOperatorType.In, values);
+        
+        protected FieldFilterRule InternalLessThanOrEquals(DateTime dateTime)
+            => new FieldFilterRule(FieldName, QueryOperatorType.LessThanOrEquals, dateTime);
+        
+        protected FieldFilterRule InternalLessThanOrEquals(DateTimeOffset dateTimeOffset)
+            => new FieldFilterRule(FieldName, QueryOperatorType.LessThanOrEquals, dateTimeOffset);
+
+        protected FieldFilterRule InternalAutocomplete(string value)
+            => new FieldFilterRule(FieldName, QueryOperatorType.Autocomplete, value);
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/BaseFieldToFilter.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/BaseFieldToFilter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 74e8928efc6d4ee886ac7cfe424bd1d8
+timeCreated: 1674050083

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7d821585988d4e209ba8e14a56cb8e9b
+timeCreated: 1674050039

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCid.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCid.cs
@@ -7,33 +7,33 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
     /// <summary>
     /// Filter by <see cref="IStreamChannel.Cid"/>
     /// </summary>
-    public class ChannelFieldCid : BaseFieldToFilter
+    public sealed class ChannelFieldCid : BaseFieldToFilter
     {
         public override string FieldName => "cid";
 
         /// <summary>
-        /// Return only channels where <see cref="IStreamChannel.Cid"/> is equal to provided channel Cid
+        /// Return only channels where <see cref="IStreamChannel.Cid"/> is EQUAL to provided channel Cid
         /// </summary>
         public FieldFilterRule EqualsTo(string channelCid) => InternalEqualsTo(channelCid);
 
         /// <summary>
-        /// Return only channels where <see cref="IStreamChannel.Cid"/> contain any of provided channel Cid
+        /// Return only channels where <see cref="IStreamChannel.Cid"/> is EQUAL to ANY of provided channel Cid
         /// </summary>
         public FieldFilterRule In(IEnumerable<string> channelCids) => InternalIn(channelCids);
         
         /// <summary>
-        /// Return only channels where <see cref="IStreamChannel.Cid"/> contain any of provided channel Cid
+        /// Return only channels where <see cref="IStreamChannel.Cid"/> is EQUAL to ANY of provided channel Cid
         /// </summary>
         public FieldFilterRule In(params string[] channelCids) => InternalIn(channelCids);
 
         /// <summary>
-        /// Return only channels where <see cref="IStreamChannel.Cid"/> contain any of the provided channels Cid
+        /// Return only channels where <see cref="IStreamChannel.Cid"/> is EQUAL to ANY of the provided channels Cid
         /// </summary>
         public FieldFilterRule In(IEnumerable<IStreamChannel> channels)
             => InternalIn(channels.Select(_ => _.Cid));
 
         /// <summary>
-        /// Return only channels where <see cref="IStreamChannel.Cid"/> contain any of the provided channels Cid
+        /// Return only channels where <see cref="IStreamChannel.Cid"/> is EQUAL to ANY of the provided channels Cid
         /// </summary>
         public FieldFilterRule In(params IStreamChannel[] channels)
             => InternalIn(channels.Select(_ => _.Cid));

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCid.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCid.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel.Cid"/>
+    /// </summary>
+    public class ChannelFieldCid : BaseFieldToFilter
+    {
+        public override string FieldName => "cid";
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Cid"/> is equal to provided channel Cid
+        /// </summary>
+        public FieldFilterRule EqualsTo(string channelCid) => InternalEqualsTo(channelCid);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Cid"/> contain any of provided channel Cid
+        /// </summary>
+        public FieldFilterRule In(IEnumerable<string> channelCids) => InternalIn(channelCids);
+        
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Cid"/> contain any of provided channel Cid
+        /// </summary>
+        public FieldFilterRule In(params string[] channelCids) => InternalIn(channelCids);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Cid"/> contain any of the provided channels Cid
+        /// </summary>
+        public FieldFilterRule In(IEnumerable<IStreamChannel> channels)
+            => InternalIn(channels.Select(_ => _.Cid));
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Cid"/> contain any of the provided channels Cid
+        /// </summary>
+        public FieldFilterRule In(params IStreamChannel[] channels)
+            => InternalIn(channels.Select(_ => _.Cid));
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCid.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCid.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 56edc92117e0417888b6b63e82f1570d
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCreatedAt.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCreatedAt.cs
@@ -1,12 +1,66 @@
-﻿using StreamChat.Core.StatefulModels;
+﻿using System;
+using StreamChat.Core.StatefulModels;
 
 namespace StreamChat.Core.QueryBuilders.Filters.Channels
 {
     /// <summary>
     /// Filter by <see cref="IStreamChannel.CreatedAt"/>
     /// </summary>
-    public class ChannelFieldCreatedAt : BaseFieldToFilter
+    public sealed class ChannelFieldCreatedAt : BaseFieldToFilter
     {
-        public override string FieldName => "CREATED_AT";
+        public override string FieldName => "created_at";
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.CreatedAt"/> is EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule EqualsTo(DateTime createdAt) => InternalEqualsTo(createdAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.CreatedAt"/> is EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule EqualsTo(DateTimeOffset createdAt) => InternalEqualsTo(createdAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.CreatedAt"/> is GREATER THAN the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThan(DateTime createdAt) => InternalGreaterThan(createdAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.CreatedAt"/> is GREATER THAN the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThan(DateTimeOffset createdAt) => InternalGreaterThan(createdAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.CreatedAt"/> is GREATER THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThanOrEquals(DateTime createdAt)
+            => InternalGreaterThanOrEquals(createdAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.CreatedAt"/> is GREATER THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThanOrEquals(DateTimeOffset createdAt)
+            => InternalGreaterThanOrEquals(createdAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.CreatedAt"/> is LESS THAN the provided one
+        /// </summary>
+        public FieldFilterRule LessThan(DateTime createdAt) => InternalLessThan(createdAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.CreatedAt"/> is LESS THAN the provided one
+        /// </summary>
+        public FieldFilterRule LessThan(DateTimeOffset createdAt) => InternalLessThan(createdAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.CreatedAt"/> is LESS THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule LessThanOrEquals(DateTime createdAt) => InternalLessThanOrEquals(createdAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.CreatedAt"/> is LESS THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule LessThanOrEquals(DateTimeOffset createdAt)
+            => InternalLessThanOrEquals(createdAt);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCreatedAt.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCreatedAt.cs
@@ -1,0 +1,12 @@
+﻿using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel.CreatedAt"/>
+    /// </summary>
+    public class ChannelFieldCreatedAt : BaseFieldToFilter
+    {
+        public override string FieldName => "CREATED_AT";
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCreatedAt.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCreatedAt.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d8408b5b1c2144ebbdaa7afb53e1fdae
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCreatedById.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCreatedById.cs
@@ -1,0 +1,16 @@
+﻿using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamUser.Id"/> of a user who created the <see cref="IStreamChannel"/>
+    /// </summary>
+    public class ChannelFieldCreatedById : BaseFieldToFilter
+    {
+        public override string FieldName => "CREATED_BY_ID";
+        
+        public FieldFilterRule EqualsTo(string id) => InternalEqualsTo(id);
+        
+        public FieldFilterRule EqualsTo(IStreamUser user) => InternalEqualsTo(user.Id);
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCreatedById.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCreatedById.cs
@@ -5,12 +5,23 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
     /// <summary>
     /// Filter by <see cref="IStreamUser.Id"/> of a user who created the <see cref="IStreamChannel"/>
     /// </summary>
-    public class ChannelFieldCreatedById : BaseFieldToFilter
+    public sealed class ChannelFieldCreatedById : BaseFieldToFilter
     {
-        public override string FieldName => "CREATED_BY_ID";
+        public override string FieldName => "created_by_id";
         
-        public FieldFilterRule EqualsTo(string id) => InternalEqualsTo(id);
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.CreatedBy"/> is EQUAL to the provided user ID
+        /// </summary>
+        public FieldFilterRule EqualsTo(string userId) => InternalEqualsTo(userId);
         
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.CreatedBy"/> is EQUAL to the provided user
+        /// </summary>
         public FieldFilterRule EqualsTo(IStreamUser user) => InternalEqualsTo(user.Id);
+        
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.CreatedBy"/> is EQUAL to the local user
+        /// </summary>
+        public FieldFilterRule EqualsTo(IStreamLocalUserData localUserData) => InternalEqualsTo(localUserData.UserId);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCreatedById.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCreatedById.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d7be9239a4e246f4a805d9dac66e4e57
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCustom.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCustom.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using StreamChat.Core.State;
+using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel"/> custom field. Custom fields can be defined in <see cref="IStreamChatClient.GetOrCreateChannelWithIdAsync"/>,
+    /// <see cref="IStreamChatClient.GetOrCreateChannelWithMembersAsync"/>, or <see cref="IStreamChannel.UpdatePartialAsync"/>
+    /// </summary>
+    public sealed class ChannelFieldCustom : BaseFieldToFilter
+    {
+        public override string FieldName { get; }
+
+        public ChannelFieldCustom(string customFieldName)
+        {
+            StreamAsserts.AssertNotNullOrEmpty(customFieldName, nameof(customFieldName));
+            FieldName = customFieldName;
+        }
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel"/> custom field has value EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule EqualsTo(string value) => InternalEqualsTo(value);
+        
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel"/> custom field has value EQUAL to ANY of provided channel Id.
+        /// </summary>
+        public FieldFilterRule In(IEnumerable<string> values) => InternalIn(values);
+        
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel"/> custom field has value EQUAL to ANY of provided channel Id.
+        /// </summary>
+        public FieldFilterRule In(params string[] values) => InternalIn(values);
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCustom.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldCustom.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 74868ef6eb86421c9e4d525e7635265f
+timeCreated: 1674508316

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldDisabled.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldDisabled.cs
@@ -1,0 +1,12 @@
+﻿using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel.Disabled"/>
+    /// </summary>
+    public class ChannelFieldDisabled : BaseFieldToFilter
+    {
+        public override string FieldName => "DISABLED";
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldDisabled.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldDisabled.cs
@@ -5,8 +5,13 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
     /// <summary>
     /// Filter by <see cref="IStreamChannel.Disabled"/>
     /// </summary>
-    public class ChannelFieldDisabled : BaseFieldToFilter
+    public sealed class ChannelFieldDisabled : BaseFieldToFilter
     {
-        public override string FieldName => "DISABLED";
+        public override string FieldName => "disabled";
+        
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Disabled"/> state is EQUAL to the provided value
+        /// </summary>
+        public FieldFilterRule EqualsTo(bool isDisabled) => InternalEqualsTo(isDisabled);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldDisabled.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldDisabled.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 87a4b1becb314a31aa9180392eb2b04e
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldFrozen.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldFrozen.cs
@@ -5,10 +5,13 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
     /// <summary>
     /// Filter by <see cref="IStreamChannel.Frozen"/>
     /// </summary>
-    public class ChannelFieldFrozen : BaseFieldToFilter
+    public sealed class ChannelFieldFrozen : BaseFieldToFilter
     {
         public override string FieldName => "frozen";
 
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Frozen"/> state is EQUAL to the provided value
+        /// </summary>
         public FieldFilterRule EqualsTo(bool isFrozen) => InternalEqualsTo(isFrozen);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldFrozen.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldFrozen.cs
@@ -1,0 +1,14 @@
+﻿using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel.Frozen"/>
+    /// </summary>
+    public class ChannelFieldFrozen : BaseFieldToFilter
+    {
+        public override string FieldName => "frozen";
+
+        public FieldFilterRule EqualsTo(bool isFrozen) => InternalEqualsTo(isFrozen);
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldFrozen.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldFrozen.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ca28cc2f1b0240b395dff66a4155c11c
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldHidden.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldHidden.cs
@@ -5,12 +5,12 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
     /// <summary>
     /// Filter by <see cref="IStreamChannel.Hidden"/>
     /// </summary>
-    public class ChannelFieldHidden : BaseFieldToFilter
+    public sealed class ChannelFieldHidden : BaseFieldToFilter
     {
         public override string FieldName => "hidden";
 
         /// <summary>
-        /// Return only channels where <see cref="IStreamChannel.Hidden"/> state is equal to provided value
+        /// Return only channels where <see cref="IStreamChannel.Hidden"/> state is EQUAL to the provided value
         /// </summary>
         public FieldFilterRule EqualsTo(bool isHidden) => InternalEqualsTo(isHidden);
     }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldHidden.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldHidden.cs
@@ -1,0 +1,17 @@
+﻿using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel.Hidden"/>
+    /// </summary>
+    public class ChannelFieldHidden : BaseFieldToFilter
+    {
+        public override string FieldName => "hidden";
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Hidden"/> state is equal to provided value
+        /// </summary>
+        public FieldFilterRule EqualsTo(bool isHidden) => InternalEqualsTo(isHidden);
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldHidden.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldHidden.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4e1a6c49216f4e3aaaeb41a2d03b5395
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldId.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldId.cs
@@ -7,33 +7,33 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
     /// <summary>
     /// Filter by <see cref="IStreamChannel.Id"/>. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
     /// </summary>
-    public class ChannelFieldId : BaseFieldToFilter
+    public sealed class ChannelFieldId : BaseFieldToFilter
     {
         public override string FieldName => "id";
         
         /// <summary>
-        /// Return only channels where <see cref="IStreamChannel.Id"/> is equal to provided channel Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
+        /// Return only channels where <see cref="IStreamChannel.Id"/> is EQUAL to provided channel Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
         /// </summary>
         public FieldFilterRule EqualsTo(string channelCid) => InternalEqualsTo(channelCid);
 
         /// <summary>
-        /// Return only channels where <see cref="IStreamChannel.Id"/> contain any of provided channel Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
+        /// Return only channels where <see cref="IStreamChannel.Id"/> is EQUAL to ANY of provided channel Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
         /// </summary>
         public FieldFilterRule In(IEnumerable<string> channelCids) => InternalIn(channelCids);
         
         /// <summary>
-        /// Return only channels where <see cref="IStreamChannel.Id"/> contain any of provided channel Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
+        /// Return only channels where <see cref="IStreamChannel.Id"/> is EQUAL to ANY of provided channel Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
         /// </summary>
         public FieldFilterRule In(params string[] channelCids) => InternalIn(channelCids);
 
         /// <summary>
-        /// Return only channels where <see cref="IStreamChannel.Id"/> contain any of the provided channels Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
+        /// Return only channels where <see cref="IStreamChannel.Id"/> is EQUAL to ANY of the provided channels Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
         /// </summary>
         public FieldFilterRule In(IEnumerable<IStreamChannel> channels)
             => InternalIn(channels.Select(_ => _.Id));
 
         /// <summary>
-        /// Return only channels where <see cref="IStreamChannel.Id"/> contain any of the provided channels Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
+        /// Return only channels where <see cref="IStreamChannel.Id"/> is EQUAL to ANY of the provided channels Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
         /// </summary>
         public FieldFilterRule In(params IStreamChannel[] channels)
             => InternalIn(channels.Select(_ => _.Id));

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldId.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldId.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel.Id"/>. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
+    /// </summary>
+    public class ChannelFieldId : BaseFieldToFilter
+    {
+        public override string FieldName => "id";
+        
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Id"/> is equal to provided channel Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
+        /// </summary>
+        public FieldFilterRule EqualsTo(string channelCid) => InternalEqualsTo(channelCid);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Id"/> contain any of provided channel Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
+        /// </summary>
+        public FieldFilterRule In(IEnumerable<string> channelCids) => InternalIn(channelCids);
+        
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Id"/> contain any of provided channel Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
+        /// </summary>
+        public FieldFilterRule In(params string[] channelCids) => InternalIn(channelCids);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Id"/> contain any of the provided channels Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
+        /// </summary>
+        public FieldFilterRule In(IEnumerable<IStreamChannel> channels)
+            => InternalIn(channels.Select(_ => _.Id));
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Id"/> contain any of the provided channels Id. If possible, you should filter by <see cref="IStreamChannel.Cid"/> which is much faster
+        /// </summary>
+        public FieldFilterRule In(params IStreamChannel[] channels)
+            => InternalIn(channels.Select(_ => _.Id));
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldId.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldId.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 70817078737f44b6a63b029fa27d201e
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldInvite.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldInvite.cs
@@ -1,0 +1,14 @@
+﻿using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel.Invite"/>
+    /// </summary>
+    public class ChannelFieldInvite : BaseFieldToFilter
+    {
+        public override string FieldName => "INVITE";
+        
+        public FieldFilterRule EqualsTo(bool isInvited) => InternalEqualsTo(isInvited);
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldInvite.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldInvite.cs
@@ -1,14 +1,37 @@
-﻿using StreamChat.Core.StatefulModels;
+﻿using System;
+using StreamChat.Core.StatefulModels;
 
 namespace StreamChat.Core.QueryBuilders.Filters.Channels
 {
     /// <summary>
     /// Filter by <see cref="IStreamChannel.Invite"/>
     /// </summary>
-    public class ChannelFieldInvite : BaseFieldToFilter
+    public sealed class ChannelFieldInvite : BaseFieldToFilter
     {
-        public override string FieldName => "INVITE";
+        public enum Status
+        {
+            Pending,
+            Accepted,
+            Rejected
+        }
         
-        public FieldFilterRule EqualsTo(bool isInvited) => InternalEqualsTo(isInvited);
+        public override string FieldName => "invite";
+        
+        /// <summary>
+        /// Return only channels where Invite status is EQUAL to the provided value
+        /// </summary>
+        public FieldFilterRule EqualsTo(Status inviteStatus) => InternalEqualsTo(StatusToString(inviteStatus));
+
+        private static string StatusToString(Status status)
+        {
+            switch (status)
+            {
+                case Status.Pending: return "pending";
+                case Status.Accepted: return "accepted";
+                case Status.Rejected: return "rejected";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(status), status, null);
+            }
+        }
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldInvite.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldInvite.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5b882109c44e45b585574eb9a842e28d
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldJoined.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldJoined.cs
@@ -3,8 +3,10 @@
     /// <summary>
     /// Filter by whether current user joined the channel or not
     /// </summary>
-    public class ChannelFieldJoined : BaseFieldToFilter
+    public sealed class ChannelFieldJoined : BaseFieldToFilter
     {
-        public override string FieldName => "JOINED";
+        public override string FieldName => "joined";
+        
+        public FieldFilterRule EqualsTo(bool hasJoined) => InternalEqualsTo(hasJoined);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldJoined.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldJoined.cs
@@ -1,0 +1,10 @@
+﻿namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by whether current user joined the channel or not
+    /// </summary>
+    public class ChannelFieldJoined : BaseFieldToFilter
+    {
+        public override string FieldName => "JOINED";
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldJoined.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldJoined.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 478e80c3957b403081b33b1919eec09d
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldLastMessageAt.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldLastMessageAt.cs
@@ -6,23 +6,61 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
     /// <summary>
     /// Filter by <see cref="IStreamChannel.LastMessageAt"/>
     /// </summary>
-    public class ChannelFieldLastMessageAt : BaseFieldToFilter
+    public sealed class ChannelFieldLastMessageAt : BaseFieldToFilter
     {
-        public override string FieldName => "LAST_MESSAGE_AT";
-        
-        /// <summary>
-        /// Return only channels where <see cref="IStreamChannel.LastMessageAt"/> is equal to provided one
-        /// </summary>
-        public FieldFilterRule EqualsTo(DateTime dateTime) => InternalEqualsTo(dateTime);
-        
-        /// <summary>
-        /// Return only channels where <see cref="IStreamChannel.LastMessageAt"/> is equal to provided one
-        /// </summary>
-        public FieldFilterRule EqualsTo(DateTimeOffset dateTime) => InternalEqualsTo(dateTime);
+        public override string FieldName => "last_message_at";
 
-        public FieldFilterRule LessThanOrEquals(DateTime dateTime) => InternalLessThanOrEquals(dateTime);
-        
-        public FieldFilterRule LessThanOrEquals(DateTimeOffset dateTimeOffset)
-            => InternalLessThanOrEquals(dateTimeOffset);
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.LastMessageAt"/> is EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule EqualsTo(DateTime lastMessageAt) => InternalEqualsTo(lastMessageAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.LastMessageAt"/> is EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule EqualsTo(DateTimeOffset lastMessageAt) => InternalEqualsTo(lastMessageAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.LastMessageAt"/> is GREATER THAN the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThan(DateTime lastMessageAt) => InternalGreaterThan(lastMessageAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.LastMessageAt"/> is GREATER THAN the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThan(DateTimeOffset lastMessageAt) => InternalGreaterThan(lastMessageAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.LastMessageAt"/> is GREATER THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThanOrEquals(DateTime lastMessageAt)
+            => InternalGreaterThanOrEquals(lastMessageAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.LastMessageAt"/> is GREATER THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThanOrEquals(DateTimeOffset lastMessageAt)
+            => InternalGreaterThanOrEquals(lastMessageAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.LastMessageAt"/> is LESS THAN the provided one
+        /// </summary>
+        public FieldFilterRule LessThan(DateTime lastMessageAt) => InternalLessThan(lastMessageAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.LastMessageAt"/> is LESS THAN the provided one
+        /// </summary>
+        public FieldFilterRule LessThan(DateTimeOffset lastMessageAt) => InternalLessThan(lastMessageAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.LastMessageAt"/> is LESS THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule LessThanOrEquals(DateTime lastMessageAt) => InternalLessThanOrEquals(lastMessageAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.LastMessageAt"/> is LESS THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule LessThanOrEquals(DateTimeOffset lastMessageAt)
+            => InternalLessThanOrEquals(lastMessageAt);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldLastMessageAt.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldLastMessageAt.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel.LastMessageAt"/>
+    /// </summary>
+    public class ChannelFieldLastMessageAt : BaseFieldToFilter
+    {
+        public override string FieldName => "LAST_MESSAGE_AT";
+        
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.LastMessageAt"/> is equal to provided one
+        /// </summary>
+        public FieldFilterRule EqualsTo(DateTime dateTime) => InternalEqualsTo(dateTime);
+        
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.LastMessageAt"/> is equal to provided one
+        /// </summary>
+        public FieldFilterRule EqualsTo(DateTimeOffset dateTime) => InternalEqualsTo(dateTime);
+
+        public FieldFilterRule LessThanOrEquals(DateTime dateTime) => InternalLessThanOrEquals(dateTime);
+        
+        public FieldFilterRule LessThanOrEquals(DateTimeOffset dateTimeOffset)
+            => InternalLessThanOrEquals(dateTimeOffset);
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldLastMessageAt.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldLastMessageAt.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ed59f14043104eefa80583063030bfb2
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldLastUpdated.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldLastUpdated.cs
@@ -1,0 +1,7 @@
+﻿namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    public class ChannelFieldLastUpdated : BaseFieldToFilter
+    {
+        public override string FieldName => "LAST_UPDATED";
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldLastUpdated.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldLastUpdated.cs
@@ -1,7 +1,60 @@
-﻿namespace StreamChat.Core.QueryBuilders.Filters.Channels
+﻿using System;
+using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
 {
-    public class ChannelFieldLastUpdated : BaseFieldToFilter
+    public sealed class ChannelFieldLastUpdated : BaseFieldToFilter
     {
-        public override string FieldName => "LAST_UPDATED";
+        public override string FieldName => "last_updated";
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule EqualsTo(DateTime updatedAt) => InternalEqualsTo(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule EqualsTo(DateTimeOffset updatedAt) => InternalEqualsTo(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is GREATER THAN the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThan(DateTime updatedAt) => InternalGreaterThan(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is GREATER THAN the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThan(DateTimeOffset updatedAt) => InternalGreaterThan(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is GREATER THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThanOrEquals(DateTime updatedAt) => InternalGreaterThanOrEquals(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is GREATER THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThanOrEquals(DateTimeOffset updatedAt) => InternalGreaterThanOrEquals(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is LESS THAN the provided one
+        /// </summary>
+        public FieldFilterRule LessThan(DateTime updatedAt) => InternalLessThan(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is LESS THAN the provided one
+        /// </summary>
+        public FieldFilterRule LessThan(DateTimeOffset updatedAt) => InternalLessThan(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is LESS THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule LessThanOrEquals(DateTime updatedAt) => InternalLessThanOrEquals(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is LESS THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule LessThanOrEquals(DateTimeOffset updatedAt) => InternalLessThanOrEquals(updatedAt);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldLastUpdated.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldLastUpdated.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 42f2a6fa57e74a89b846e93853d7ea46
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMemberCount.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMemberCount.cs
@@ -1,0 +1,12 @@
+﻿using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel"/> members count
+    /// </summary>
+    public class ChannelFieldMemberCount : BaseFieldToFilter
+    {
+        public override string FieldName => "MEMBER_COUNT";
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMemberCount.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMemberCount.cs
@@ -5,8 +5,33 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
     /// <summary>
     /// Filter by <see cref="IStreamChannel"/> members count
     /// </summary>
-    public class ChannelFieldMemberCount : BaseFieldToFilter
+    public sealed class ChannelFieldMemberCount : BaseFieldToFilter
     {
-        public override string FieldName => "MEMBER_COUNT";
+        public override string FieldName => "member_count";
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Members"/> count is EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule EqualsTo(int memberCount) => InternalEqualsTo(memberCount);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Members"/> count is GREATER THAN the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThan(int memberCount) => InternalGreaterThan(memberCount);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Members"/> count is GREATER THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThanOrEquals(int memberCount) => InternalGreaterThanOrEquals(memberCount);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Members"/> count is LESS THAN the provided one
+        /// </summary>
+        public FieldFilterRule LessThan(int memberCount) => InternalLessThan(memberCount);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Members"/> count is LESS THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule LessThanOrEquals(int memberCount) => InternalLessThanOrEquals(memberCount);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMemberCount.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMemberCount.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 10682c07f4c44439b59f13e815d75aef
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMemberUserName.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMemberUserName.cs
@@ -1,0 +1,20 @@
+﻿using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamUser.Name"/> who is a member of 
+    /// </summary>
+    public class ChannelFieldMemberUserName : BaseFieldToFilter
+    {
+        public override string FieldName => "MEMBER.USER.NAME";
+        
+        public FieldFilterRule EqualsTo(string userName) => InternalEqualsTo(userName);
+        
+        public FieldFilterRule EqualsTo(IStreamUser user) => InternalEqualsTo(user.Name);
+        
+        public FieldFilterRule Autocomplete(string userName) => InternalAutocomplete(userName);
+        
+        public FieldFilterRule Autocomplete(IStreamUser user) => InternalAutocomplete(user.Name);
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMemberUserName.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMemberUserName.cs
@@ -5,16 +5,23 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
     /// <summary>
     /// Filter by <see cref="IStreamUser.Name"/> who is a member of 
     /// </summary>
-    public class ChannelFieldMemberUserName : BaseFieldToFilter
+    public sealed class ChannelFieldMemberUserName : BaseFieldToFilter
     {
-        public override string FieldName => "MEMBER.USER.NAME";
+        public override string FieldName => "member.user.name";
         
+        /// <summary>
+        /// Return only channels where a MEMBER <see cref="IStreamUser.Name"/> is EQUAL to the provided value
+        /// </summary>
         public FieldFilterRule EqualsTo(string userName) => InternalEqualsTo(userName);
         
+        /// <summary>
+        /// Return only channels where a MEMBER <see cref="IStreamUser.Name"/> is EQUAL to the provided user
+        /// </summary>
         public FieldFilterRule EqualsTo(IStreamUser user) => InternalEqualsTo(user.Name);
         
-        public FieldFilterRule Autocomplete(string userName) => InternalAutocomplete(userName);
-        
-        public FieldFilterRule Autocomplete(IStreamUser user) => InternalAutocomplete(user.Name);
+        /// <summary>
+        /// Return only channels where a MEMBER <see cref="IStreamUser.Name"/> CONTAINS provided phrase anywhere. Example: "An" would match "Anna", "Daniel", "Jonathan" because they all contain the "an"
+        /// </summary>
+        public FieldFilterRule Autocomplete(string phrase) => InternalAutocomplete(phrase);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMemberUserName.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMemberUserName.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2a23f0ca314640f3a98c2c0f98f4e349
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMembers.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMembers.cs
@@ -7,9 +7,9 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
     /// <summary>
     /// Filter by <see cref="IStreamChannel.Members"/>
     /// </summary>
-    public class ChannelFieldMembers : BaseFieldToFilter
+    public sealed class ChannelFieldMembers : BaseFieldToFilter
     {
-        public override string FieldName => "MEMBERS";
+        public override string FieldName => "members";
 
         /// <summary>
         /// Return only channels where <see cref="IStreamChannel.Members"/> contains a user with provided user ID

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMembers.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMembers.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel.Members"/>
+    /// </summary>
+    public class ChannelFieldMembers : BaseFieldToFilter
+    {
+        public override string FieldName => "MEMBERS";
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Members"/> contains a user with provided user ID
+        /// </summary>
+        public FieldFilterRule EqualsTo(string userId) => InternalEqualsTo(userId);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Members"/> contain any of the users with provided user IDs
+        /// </summary>
+        public FieldFilterRule In(IEnumerable<string> userIds) => InternalIn(userIds);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Members"/> contain any of the users with provided user IDs
+        /// </summary>
+        public FieldFilterRule In(IEnumerable<IStreamUser> userIds)
+            => InternalIn(userIds.Select(_ => _.Id));
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Members"/> contain any of the users with provided user IDs
+        /// </summary>
+        public FieldFilterRule In(IEnumerable<IStreamChannelMember> userIds)
+            => InternalIn(userIds.Select(_ => _.User.Id));
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMembers.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMembers.cs
@@ -20,17 +20,34 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
         /// Return only channels where <see cref="IStreamChannel.Members"/> contain any of the users with provided user IDs
         /// </summary>
         public FieldFilterRule In(IEnumerable<string> userIds) => InternalIn(userIds);
+        
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Members"/> contain any of the users with provided user IDs
+        /// </summary>
+        public FieldFilterRule In(params string[] userIds) => InternalIn(userIds);
 
         /// <summary>
         /// Return only channels where <see cref="IStreamChannel.Members"/> contain any of the users with provided user IDs
         /// </summary>
         public FieldFilterRule In(IEnumerable<IStreamUser> userIds)
             => InternalIn(userIds.Select(_ => _.Id));
+        
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Members"/> contain any of the users with provided user IDs
+        /// </summary>
+        public FieldFilterRule In(params IStreamUser[] userIds)
+            => InternalIn(userIds.Select(_ => _.Id));
 
         /// <summary>
         /// Return only channels where <see cref="IStreamChannel.Members"/> contain any of the users with provided user IDs
         /// </summary>
         public FieldFilterRule In(IEnumerable<IStreamChannelMember> userIds)
+            => InternalIn(userIds.Select(_ => _.User.Id));
+        
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Members"/> contain any of the users with provided user IDs
+        /// </summary>
+        public FieldFilterRule In(params IStreamChannelMember[] userIds)
             => InternalIn(userIds.Select(_ => _.User.Id));
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMembers.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMembers.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 681e35c816684e9593824151bece25c7
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMuted.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMuted.cs
@@ -1,0 +1,14 @@
+﻿using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel.Muted"/>
+    /// </summary>
+    public class ChannelFieldMuted : BaseFieldToFilter
+    {
+        public override string FieldName => "MUTED";
+        
+        public FieldFilterRule EqualsTo(bool isMuted) => InternalEqualsTo(isMuted);
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMuted.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMuted.cs
@@ -5,10 +5,13 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
     /// <summary>
     /// Filter by <see cref="IStreamChannel.Muted"/>
     /// </summary>
-    public class ChannelFieldMuted : BaseFieldToFilter
+    public sealed class ChannelFieldMuted : BaseFieldToFilter
     {
-        public override string FieldName => "MUTED";
+        public override string FieldName => "muted";
         
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Muted"/> state is EQUAL to the provided value
+        /// </summary>
         public FieldFilterRule EqualsTo(bool isMuted) => InternalEqualsTo(isMuted);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMuted.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldMuted.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c68cf7fdbf274082ac904520edd9ec16
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldTeam.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldTeam.cs
@@ -5,8 +5,13 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
     /// <summary>
     /// Filter by <see cref="IStreamChannel.Team"/>
     /// </summary>
-    public class ChannelFieldTeam : BaseFieldToFilter
+    public sealed class ChannelFieldTeam : BaseFieldToFilter
     {
-        public override string FieldName => "TEAM";
+        public override string FieldName => "team";
+        
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Team"/> state is EQUAL to the provided value
+        /// </summary>
+        public FieldFilterRule EqualsTo(string team) => InternalEqualsTo(team);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldTeam.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldTeam.cs
@@ -1,0 +1,12 @@
+﻿using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel.Team"/>
+    /// </summary>
+    public class ChannelFieldTeam : BaseFieldToFilter
+    {
+        public override string FieldName => "TEAM";
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldTeam.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldTeam.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4676a312a73f488a9ae1132451d2454c
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldType.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldType.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel.Type"/>
+    /// </summary>
+    public class ChannelFieldType : BaseFieldToFilter
+    {
+        public override string FieldName => "type";
+
+        public FieldFilterRule EqualsTo(ChannelType channelType)
+            => InternalEqualsTo(channelType.ToString());
+
+        public FieldFilterRule In(IEnumerable<ChannelType> channelTypes)
+            => InternalIn(channelTypes.Select(_ => _.ToString()));
+        
+        public FieldFilterRule In(params ChannelType[] channelTypes)
+            => InternalIn(channelTypes.Select(_ => _.ToString()));
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldType.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldType.cs
@@ -7,16 +7,25 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
     /// <summary>
     /// Filter by <see cref="IStreamChannel.Type"/>
     /// </summary>
-    public class ChannelFieldType : BaseFieldToFilter
+    public sealed class ChannelFieldType : BaseFieldToFilter
     {
         public override string FieldName => "type";
 
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Type"/> state is EQUAL to the provided value
+        /// </summary>
         public FieldFilterRule EqualsTo(ChannelType channelType)
             => InternalEqualsTo(channelType.ToString());
 
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Type"/> is EQUAL to ANY of provided values
+        /// </summary>
         public FieldFilterRule In(IEnumerable<ChannelType> channelTypes)
             => InternalIn(channelTypes.Select(_ => _.ToString()));
         
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.Type"/> is EQUAL to ANY of provided values
+        /// </summary>
         public FieldFilterRule In(params ChannelType[] channelTypes)
             => InternalIn(channelTypes.Select(_ => _.ToString()));
     }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldType.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldType.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1eea66d5387a4092a4fa7ea3087d3585
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldUpdatedAt.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldUpdatedAt.cs
@@ -1,12 +1,63 @@
-﻿using StreamChat.Core.StatefulModels;
+﻿using System;
+using StreamChat.Core.StatefulModels;
 
 namespace StreamChat.Core.QueryBuilders.Filters.Channels
 {
     /// <summary>
     /// Filter by <see cref="IStreamChannel.UpdatedAt"/>
     /// </summary>
-    public class ChannelFieldUpdatedAt : BaseFieldToFilter
+    public sealed class ChannelFieldUpdatedAt : BaseFieldToFilter
     {
-        public override string FieldName => "UPDATED_AT";
+        public override string FieldName => "updated_at";
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule EqualsTo(DateTime updatedAt) => InternalEqualsTo(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule EqualsTo(DateTimeOffset updatedAt) => InternalEqualsTo(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is GREATER THAN the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThan(DateTime updatedAt) => InternalGreaterThan(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is GREATER THAN the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThan(DateTimeOffset updatedAt) => InternalGreaterThan(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is GREATER THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThanOrEquals(DateTime updatedAt) => InternalGreaterThanOrEquals(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is GREATER THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule GreaterThanOrEquals(DateTimeOffset updatedAt) => InternalGreaterThanOrEquals(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is LESS THAN the provided one
+        /// </summary>
+        public FieldFilterRule LessThan(DateTime updatedAt) => InternalLessThan(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is LESS THAN the provided one
+        /// </summary>
+        public FieldFilterRule LessThan(DateTimeOffset updatedAt) => InternalLessThan(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is LESS THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule LessThanOrEquals(DateTime updatedAt) => InternalLessThanOrEquals(updatedAt);
+
+        /// <summary>
+        /// Return only channels where <see cref="IStreamChannel.UpdatedAt"/> is LESS THAN OR EQUAL to the provided one
+        /// </summary>
+        public FieldFilterRule LessThanOrEquals(DateTimeOffset updatedAt) => InternalLessThanOrEquals(updatedAt);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldUpdatedAt.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldUpdatedAt.cs
@@ -1,0 +1,12 @@
+﻿using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filter by <see cref="IStreamChannel.UpdatedAt"/>
+    /// </summary>
+    public class ChannelFieldUpdatedAt : BaseFieldToFilter
+    {
+        public override string FieldName => "UPDATED_AT";
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldUpdatedAt.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFieldUpdatedAt.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 773f80aea93144e8a783ea4b76d4b6bc
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFilter.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFilter.cs
@@ -1,0 +1,61 @@
+﻿using StreamChat.Core.StatefulModels;
+
+namespace StreamChat.Core.QueryBuilders.Filters.Channels
+{
+    /// <summary>
+    /// Filters for <see cref="IStreamChannel"/> query filters in <see cref="IStreamChatClient.QueryChannelsAsync"/>
+    /// </summary>
+    public static class ChannelFilter
+    {
+        /// <inheritdoc cref="ChannelFieldFrozen"/>
+        public static ChannelFieldFrozen Frozen { get; } = new ChannelFieldFrozen();
+
+        /// <inheritdoc cref="ChannelFieldType"/>
+        public static ChannelFieldType Type { get; } = new ChannelFieldType();
+
+        /// <inheritdoc cref="ChannelFieldId"/>
+        public static ChannelFieldId Id { get; } = new ChannelFieldId();
+
+        /// <inheritdoc cref="ChannelFieldCid"/>
+        public static ChannelFieldCid Cid { get; } = new ChannelFieldCid();
+
+        /// <inheritdoc cref="ChannelFieldMembers"/>
+        public static ChannelFieldMembers Members { get; } = new ChannelFieldMembers();
+
+        /// <inheritdoc cref="ChannelFieldInvite"/>
+        public static ChannelFieldInvite Invite { get; } = new ChannelFieldInvite();
+
+        /// <inheritdoc cref="ChannelFieldJoined"/>
+        public static ChannelFieldJoined Joined { get; } = new ChannelFieldJoined();
+
+        /// <inheritdoc cref="ChannelFieldMuted"/>
+        public static ChannelFieldMuted Muted { get; } = new ChannelFieldMuted();
+
+        /// <inheritdoc cref="ChannelFieldMemberUserName"/>
+        public static ChannelFieldMemberUserName MemberUserName { get; } = new ChannelFieldMemberUserName();
+
+        /// <inheritdoc cref="ChannelFieldCreatedById"/>
+        public static ChannelFieldCreatedById CreatedById { get; } = new ChannelFieldCreatedById();
+
+        /// <inheritdoc cref="ChannelFieldHidden"/>
+        public static ChannelFieldHidden Hidden { get; } = new ChannelFieldHidden();
+
+        /// <inheritdoc cref="ChannelFieldLastMessageAt"/>
+        public static ChannelFieldLastMessageAt LastMessageAt { get; } = new ChannelFieldLastMessageAt();
+
+        /// <inheritdoc cref="ChannelFieldMemberCount"/>
+        public static ChannelFieldMemberCount MembersCount { get; } = new ChannelFieldMemberCount();
+
+        /// <inheritdoc cref="ChannelFieldCreatedAt"/>
+        public static ChannelFieldCreatedAt CreatedAt { get; } = new ChannelFieldCreatedAt();
+
+        /// <inheritdoc cref="ChannelFieldUpdatedAt"/>
+        public static ChannelFieldUpdatedAt UpdatedAt { get; } = new ChannelFieldUpdatedAt();
+
+        /// <inheritdoc cref="ChannelFieldTeam"/>
+        public static ChannelFieldTeam Team { get; } = new ChannelFieldTeam();
+
+        /// <inheritdoc cref="ChannelFieldDisabled"/>
+        public static ChannelFieldDisabled Disabled { get; } = new ChannelFieldDisabled();
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFilter.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFilter.cs
@@ -57,5 +57,8 @@ namespace StreamChat.Core.QueryBuilders.Filters.Channels
 
         /// <inheritdoc cref="ChannelFieldDisabled"/>
         public static ChannelFieldDisabled Disabled { get; } = new ChannelFieldDisabled();
+        
+        /// <inheritdoc cref="ChannelFieldCustom"/>
+        public static ChannelFieldCustom Custom(string customFieldName) => new ChannelFieldCustom(customFieldName);
     }
 }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFilter.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/Channels/ChannelFilter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5e50e4721e6240ae8e43b6d49cc8dbb7
+timeCreated: 1674050108

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/FieldFilterRule.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/FieldFilterRule.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace StreamChat.Core.QueryBuilders.Filters
+{
+    public class FieldFilterRule : IFieldFilterRule
+    {
+        public string Field { get; }
+        public QueryOperatorType OperatorType { get; }
+        public object Value { get; }
+
+        public FieldFilterRule(string field, QueryOperatorType operatorType, bool value)
+        {
+            Field = field;
+            OperatorType = operatorType;
+            Value = value;
+        }
+
+        public FieldFilterRule(string field, QueryOperatorType operatorType, string value)
+        {
+            Field = field;
+            OperatorType = operatorType;
+            Value = value;
+        }
+
+        public FieldFilterRule(string field, QueryOperatorType operatorType, DateTime value)
+        {
+            Field = field;
+            OperatorType = operatorType;
+            Value = ToRfc3339String(value);
+        }
+
+        public FieldFilterRule(string field, QueryOperatorType operatorType, DateTimeOffset value)
+        {
+            Field = field;
+            OperatorType = operatorType;
+            Value = ToRfc3339String(value);
+        }
+
+        public FieldFilterRule(string field, QueryOperatorType operatorType, IEnumerable<string> value)
+        {
+            Field = field;
+            OperatorType = operatorType;
+            Value = value.ToArray();
+        }
+
+        //StreamTodo: research how to reduce allocation here
+        public KeyValuePair<string, object> GenerateFilterEntry()
+            => new KeyValuePair<string, object>
+            (
+                Field, new Dictionary<string, object>
+                {
+                    {
+                        OperatorType.ToOperatorKeyword(), Value
+                    }
+                }
+            );
+        
+        private static string ToRfc3339String(DateTime dateTime)
+            => dateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.fffzzz", DateTimeFormatInfo.InvariantInfo);
+        
+        private static string ToRfc3339String(DateTimeOffset dateTimeOffset)
+            => dateTimeOffset.ToString("yyyy-MM-dd'T'HH:mm:ss.fffzzz", DateTimeFormatInfo.InvariantInfo);
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/FieldFilterRule.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/FieldFilterRule.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace StreamChat.Core.QueryBuilders.Filters
 {
-    public class FieldFilterRule : IFieldFilterRule
+    public sealed class FieldFilterRule : IFieldFilterRule
     {
         public string Field { get; }
         public QueryOperatorType OperatorType { get; }
@@ -19,6 +19,13 @@ namespace StreamChat.Core.QueryBuilders.Filters
         }
 
         public FieldFilterRule(string field, QueryOperatorType operatorType, string value)
+        {
+            Field = field;
+            OperatorType = operatorType;
+            Value = value;
+        }
+        
+        public FieldFilterRule(string field, QueryOperatorType operatorType, int value)
         {
             Field = field;
             OperatorType = operatorType;

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/FieldFilterRule.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/FieldFilterRule.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2635d8c469d340278b10cc4bf8bf1be3
+timeCreated: 1674050083

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/IFieldFilterRule.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/IFieldFilterRule.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace StreamChat.Core.QueryBuilders.Filters
+{
+    /// <summary>
+    /// This filter applies a rule that will be matched against specific field in a query
+    /// E.g. "ID equals 21" - checks if field `ID` is equal to `21` value 
+    /// </summary>
+    public interface IFieldFilterRule
+    {
+        string Field { get; }
+
+        KeyValuePair<string, object> GenerateFilterEntry();
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/IFieldFilterRule.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/IFieldFilterRule.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4193a6e9d7c84237ac341dd67862ee51
+timeCreated: 1674050083

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/IFieldToFilter.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/IFieldToFilter.cs
@@ -1,0 +1,7 @@
+﻿namespace StreamChat.Core.QueryBuilders.Filters
+{
+    public interface IFieldToFilter
+    {
+        string FieldName { get; }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/IFieldToFilter.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/IFieldToFilter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6ef2722f8952449fb34875c1392ef268
+timeCreated: 1674050083

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/QueryOperatorType.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/QueryOperatorType.cs
@@ -11,8 +11,6 @@ namespace StreamChat.Core.QueryBuilders.Filters
         Contains,
         And,
         Or,
-        //Nor,
-
         Equals,
         NotEquals,
         GreaterThan,
@@ -22,7 +20,6 @@ namespace StreamChat.Core.QueryBuilders.Filters
         In,
         NotIn,
         Autocomplete,
-        Distinct,
     }
     
     /// <summary>
@@ -38,7 +35,6 @@ namespace StreamChat.Core.QueryBuilders.Filters
                 case QueryOperatorType.Contains: return "$contains";
                 case QueryOperatorType.And: return "$and";
                 case QueryOperatorType.Or: return "$or";
-                //case QueryOperatorType.Nor: return "$eq";
                 case QueryOperatorType.Equals: return "$eq";
                 case QueryOperatorType.NotEquals: return "$neq";
                 case QueryOperatorType.GreaterThan: return "$gt";
@@ -48,8 +44,6 @@ namespace StreamChat.Core.QueryBuilders.Filters
                 case QueryOperatorType.In: return "$in";
                 case QueryOperatorType.NotIn: return "$nin";
                 case QueryOperatorType.Autocomplete: return "$autocomplete";
-                    //case QueryOperatorType.Distinct:
-                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(operatorType), operatorType, null);
             }

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/QueryOperatorType.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/QueryOperatorType.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+namespace StreamChat.Core.QueryBuilders.Filters
+{
+    /// <summary>
+    /// Query filter operator type
+    /// </summary>
+    public enum QueryOperatorType
+    {
+        Exists,
+        Contains,
+        And,
+        Or,
+        //Nor,
+
+        Equals,
+        NotEquals,
+        GreaterThan,
+        GreaterThanOrEquals,
+        LessThan,
+        LessThanOrEquals,
+        In,
+        NotIn,
+        Autocomplete,
+        Distinct,
+    }
+    
+    /// <summary>
+    /// Extensions for <see cref="QueryOperatorType"/>
+    /// </summary>
+    public static class QueryOperatorTypeExt
+    {
+        public static string ToOperatorKeyword(this QueryOperatorType operatorType)
+        {
+            switch (operatorType)
+            {
+                case QueryOperatorType.Exists: return "$exists";
+                case QueryOperatorType.Contains: return "$contains";
+                case QueryOperatorType.And: return "$and";
+                case QueryOperatorType.Or: return "$or";
+                //case QueryOperatorType.Nor: return "$eq";
+                case QueryOperatorType.Equals: return "$eq";
+                case QueryOperatorType.NotEquals: return "$neq";
+                case QueryOperatorType.GreaterThan: return "$gt";
+                case QueryOperatorType.GreaterThanOrEquals: return "$gte";
+                case QueryOperatorType.LessThan: return "$lt";
+                case QueryOperatorType.LessThanOrEquals: return "$lte";
+                case QueryOperatorType.In: return "$in";
+                case QueryOperatorType.NotIn: return "$nin";
+                case QueryOperatorType.Autocomplete: return "$autocomplete";
+                    //case QueryOperatorType.Distinct:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(operatorType), operatorType, null);
+            }
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/QueryOperatorType.cs.meta
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Filters/QueryOperatorType.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fceef049927e4631b8194bc993a9073b
+timeCreated: 1674050127

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSort.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSort.cs
@@ -1,10 +1,9 @@
-﻿using System.Collections.Generic;
-using StreamChat.Core.StatefulModels;
+﻿using StreamChat.Core.StatefulModels;
 
 namespace StreamChat.Core.QueryBuilders.Sort
 {
     /// <summary>
-    /// Factory for creating for <see cref="IStreamChannel"/> query <see cref="IStreamChatClient.QueryChannelsAsync(IDictionary{string,object}, ChannelSortObject, int, int)"/> sort object
+    /// Factory for <see cref="IStreamChannel"/> query <see cref="IStreamChatClient.QueryChannelsAsync"/> sort object building
     /// </summary>
     public static class ChannelSort
     {

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSortFieldName.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSortFieldName.cs
@@ -4,7 +4,7 @@ using StreamChat.Core.StatefulModels;
 namespace StreamChat.Core.QueryBuilders.Sort
 {
     /// <summary>
-    /// Field names available for <see cref="IStreamChannel"/> query: <see cref="IStreamChatClient.QueryChannelsAsync(IDictionary{string,object}, ChannelSortObject, int, int)"/>
+    /// Field names available for <see cref="IStreamChannel"/> query: <see cref="IStreamChatClient.QueryChannelsAsync"/>
     /// </summary>
     public enum ChannelSortFieldName
     {

--- a/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSortObject.cs
+++ b/Assets/Plugins/StreamChat/Core/QueryBuilders/Sort/ChannelSortObject.cs
@@ -5,7 +5,7 @@ using StreamChat.Core.StatefulModels;
 namespace StreamChat.Core.QueryBuilders.Sort
 {
     /// <summary>
-    /// Sort object for <see cref="IStreamChannel"/> query: <see cref="IStreamChatClient.QueryChannelsAsync(IDictionary{string,object}, ChannelSortObject, int, int)"/>
+    /// Sort object for <see cref="IStreamChannel"/> query: <see cref="IStreamChatClient.QueryChannelsAsync"/>
     /// </summary>
     public sealed class ChannelSortObject : QuerySort<ChannelSortObject, ChannelSortFieldName>
     {

--- a/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
@@ -245,8 +245,8 @@ namespace StreamChat.Core
                 await InternalLowLevelClient.InternalChannelApi.GetOrCreateChannelAsync(channelType, requestBodyDto);
             return _cache.TryCreateOrUpdate(channelResponseDto);
         }
-        
-        public async Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IEnumerable<IFieldFilterRule> filters,
+
+        public async Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IEnumerable<IFieldFilterRule> filters = null,
             ChannelSortObject sort = null, int limit = 30, int offset = 0)
         {
             StreamAsserts.AssertWithinRange(limit, 0, 30, nameof(limit));
@@ -288,7 +288,9 @@ namespace StreamChat.Core
             return result;
         }
 
-        public async Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters = null,
+        [Obsolete("This method will be removed in the future. Please use the other overload method that uses " +
+                  nameof(IFieldFilterRule) + " type filters")]
+        public async Task<IEnumerable<IStreamChannel>> QueryChannelsAsync(IDictionary<string, object> filters,
             ChannelSortObject sort = null, int limit = 30, int offset = 0)
         {
             StreamAsserts.AssertWithinRange(limit, 0, 30, nameof(limit));

--- a/Assets/Plugins/StreamChat/Samples/ClientIntroductionMonoBehaviour.cs
+++ b/Assets/Plugins/StreamChat/Samples/ClientIntroductionMonoBehaviour.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using StreamChat.Core;
+using StreamChat.Core.QueryBuilders.Filters;
+using StreamChat.Core.QueryBuilders.Filters.Channels;
 using StreamChat.Core.Requests;
 using StreamChat.Core.StatefulModels;
 using UnityEngine;
@@ -37,15 +39,11 @@ namespace StreamChat.Samples
 
         public async Task QueryChannelsAsync()
         {
-            var filters = new Dictionary<string, object>
+            var filters = new List<IFieldFilterRule>()
             {
-                {
-                    "members", new Dictionary<string, object>
-                    {
-                        { "$in", new string[] { "user-id-to-search" } }
-                    }
-                }
+                ChannelFilter.Members.In("user-id-to-search")
             };
+
             var channels = await _chatClient.QueryChannelsAsync(filters);
 
             foreach (var channel in channels)

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/BaseStateIntegrationTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/BaseStateIntegrationTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using StreamChat.Core;
 using StreamChat.Core.Configs;
+using StreamChat.Core.Requests;
 using StreamChat.Core.StatefulModels;
 using StreamChat.EditorTools;
 using StreamChat.Libs.Auth;
@@ -61,7 +62,7 @@ namespace StreamChat.Tests.StatefulClient
                 await Task.Delay(1);
             }
 
-            Debug.Log("Connection made: " + Client.ConnectionState);
+            Debug.Log($"Connection made: {Client.ConnectionState}, user ID: {Client.LocalUserData.User.Id}");
         }
 
         /// <summary>
@@ -74,6 +75,24 @@ namespace StreamChat.Tests.StatefulClient
             var channelState = await Client.GetOrCreateChannelWithIdAsync(ChannelType.Messaging, channelId);
             _tempChannels.Add(channelState);
             return channelState;
+        }
+        
+        /// <summary>
+        /// Create temp user with random id
+        /// </summary>
+        protected async Task<IStreamUser> CreateUniqueTempUserAsync(string name)
+        {
+            var userId = "random-user-22222-" + Guid.NewGuid() + "-" + name;
+
+            var user = await Client.UpsertUsers(new StreamUserUpsertRequest[]
+            {
+                new StreamUserUpsertRequest
+                {
+                    Id = userId,
+                    Name = name
+                }
+            });
+            return user.First();
         }
 
         /// <summary>

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQueryFiltersTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQueryFiltersTests.cs
@@ -175,7 +175,7 @@ namespace StreamChat.Tests.StatefulClient
             var channels2 = (await Client.QueryChannelsAsync(filters2, ChannelSort.OrderByAscending(ChannelSortFieldName.CreatedAt))).ToArray();
             Assert.Contains(channel1, channels2);
             Assert.IsNull(channels2.FirstOrDefault(c => c == channel2));
-            Assert.Contains(channel3, channels2);
+            Assert.IsNull(channels2.FirstOrDefault(c => c == channel3));
         }
     }
 }

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQueryFiltersTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQueryFiltersTests.cs
@@ -1,0 +1,181 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using StreamChat.Core.QueryBuilders.Filters;
+using StreamChat.Core.QueryBuilders.Filters.Channels;
+using StreamChat.Core.QueryBuilders.Sort;
+using StreamChat.Core.StatefulModels;
+using UnityEngine.TestTools;
+
+namespace StreamChat.Tests.StatefulClient
+{
+    /// <summary>
+    /// Tests operations executed on <see cref="StreamChannel"/>
+    /// </summary>
+    internal class ChannelsQueryFiltersTests : BaseStateIntegrationTests
+    {
+        [UnityTest]
+        public IEnumerator When_query_channel_with_id_in_filter_expect_valid_results()
+            => ConnectAndExecute(When_query_channel_with_id_in_filter_expect_valid_results_Async);
+
+        private async Task When_query_channel_with_id_in_filter_expect_valid_results_Async()
+        {
+            var channel1 = await CreateUniqueTempChannelAsync();
+            var channel2 = await CreateUniqueTempChannelAsync();
+            var channel3 = await CreateUniqueTempChannelAsync();
+
+            var filters = new Dictionary<string, object>
+            {
+                {
+                    "cid", new Dictionary<string, object>
+                    {
+                        {
+                            "$in", new[] { channel1.Cid, channel2.Cid, channel3.Cid }
+                        }
+                    }
+                }
+            };
+
+            var channels = (await Client.QueryChannelsAsync(filters)).ToArray();
+            Assert.Contains(channel1, channels);
+            Assert.Contains(channel2, channels);
+            Assert.Contains(channel3, channels);
+            
+            // Query builder
+
+            var filters2 = new IFieldFilterRule[]
+            {
+                ChannelFilter.Cid.In(channel1, channel2, channel3)
+            };
+
+            var channels2 = (await Client.QueryChannelsAsync(filters2, ChannelSort.OrderByAscending(ChannelSortFieldName.CreatedAt))).ToArray();
+            Assert.Contains(channel1, channels2);
+            Assert.Contains(channel2, channels2);
+            Assert.Contains(channel3, channels2);
+        }
+
+        [UnityTest]
+        public IEnumerator When_query_channel_with_id_in_and_hidden_filter_expect_valid_results()
+            => ConnectAndExecute(When_query_channel_with_id_in_and_hidden_filter_expect_valid_results_Async);
+
+        private async Task When_query_channel_with_id_in_and_hidden_filter_expect_valid_results_Async()
+        {
+            var channel1 = await CreateUniqueTempChannelAsync();
+            var channel2 = await CreateUniqueTempChannelAsync();
+            var channel3 = await CreateUniqueTempChannelAsync();
+
+            await channel2.JoinAsMemberAsync();
+
+            await channel2.HideAsync();
+
+            var filters = new Dictionary<string, object>
+            {
+                {
+                    "cid", new Dictionary<string, object>
+                    {
+                        {
+                            "$in", new[] { channel1.Cid, channel2.Cid, channel3.Cid }
+                        }
+                    }
+                },
+                {
+                    "hidden", new Dictionary<string, object>
+                    {
+                        {
+                            "$eq", false
+                        }
+                    }
+                }
+            };
+
+            var channels = (await Client.QueryChannelsAsync(filters)).ToArray();
+            Assert.Contains(channel1, channels);
+            Assert.IsNull(channels.FirstOrDefault(c => c == channel2));
+            Assert.Contains(channel3, channels);
+
+            // Query builder
+
+            var filters2 = new IFieldFilterRule[]
+            {
+                ChannelFilter.Cid.In(channel1, channel2, channel3),
+                ChannelFilter.Hidden.EqualsTo(false),
+            };
+
+            var channels2 = (await Client.QueryChannelsAsync(filters2, ChannelSort.OrderByAscending(ChannelSortFieldName.CreatedAt))).ToArray();
+            Assert.Contains(channel1, channels2);
+            Assert.IsNull(channels2.FirstOrDefault(c => c == channel2));
+            Assert.Contains(channel3, channels2);
+        }
+
+        [UnityTest]
+        public IEnumerator When_query_channel_with_id_in_and_hidden_and_frozen_filter_expect_valid_results()
+            => ConnectAndExecute(When_query_channel_with_id_in_and_hidden_and_frozen_filter_expect_valid_results_Async);
+
+        private async Task When_query_channel_with_id_in_and_hidden_and_frozen_filter_expect_valid_results_Async()
+        {
+            var channel1 = await CreateUniqueTempChannelAsync();
+            var channel2 = await CreateUniqueTempChannelAsync();
+            var channel3 = await CreateUniqueTempChannelAsync();
+
+            await channel2.JoinAsMemberAsync();
+
+            await channel2.HideAsync();
+
+            await channel3.UpdatePartialAsync(setFields: new Dictionary<string, object>()
+            {
+                { "frozen", true }
+            });
+
+            Assert.AreEqual(true, channel3.Frozen);
+
+            var filters = new Dictionary<string, object>
+            {
+                {
+                    "cid", new Dictionary<string, object>
+                    {
+                        {
+                            "$in", new[] { channel1.Cid, channel2.Cid, channel3.Cid }
+                        }
+                    }
+                },
+                {
+                    "hidden", new Dictionary<string, object>
+                    {
+                        {
+                            "$eq", false
+                        }
+                    }
+                },
+                {
+                    "frozen", new Dictionary<string, object>
+                    {
+                        {
+                            "$eq", false
+                        }
+                    }
+                }
+            };
+
+            var channels = (await Client.QueryChannelsAsync(filters)).ToArray();
+            Assert.Contains(channel1, channels);
+            Assert.IsNull(channels.FirstOrDefault(c => c == channel2));
+            Assert.IsNull(channels.FirstOrDefault(c => c == channel3));
+            
+            // Query builder
+
+            var filters2 = new IFieldFilterRule[]
+            {
+                ChannelFilter.Cid.In(channel1, channel2, channel3),
+                ChannelFilter.Hidden.EqualsTo(false),
+                ChannelFilter.Frozen.EqualsTo(false),
+            };
+
+            var channels2 = (await Client.QueryChannelsAsync(filters2, ChannelSort.OrderByAscending(ChannelSortFieldName.CreatedAt))).ToArray();
+            Assert.Contains(channel1, channels2);
+            Assert.IsNull(channels2.FirstOrDefault(c => c == channel2));
+            Assert.Contains(channel3, channels2);
+        }
+    }
+}

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQueryFiltersTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQueryFiltersTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿#if STREAM_TESTS_ENABLED
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -26,34 +27,15 @@ namespace StreamChat.Tests.StatefulClient
             var channel2 = await CreateUniqueTempChannelAsync();
             var channel3 = await CreateUniqueTempChannelAsync();
 
-            var filters = new Dictionary<string, object>
+            var filters = new IFieldFilterRule[]
             {
-                {
-                    "cid", new Dictionary<string, object>
-                    {
-                        {
-                            "$in", new[] { channel1.Cid, channel2.Cid, channel3.Cid }
-                        }
-                    }
-                }
+                ChannelFilter.Cid.In(channel1, channel2, channel3)
             };
 
             var channels = (await Client.QueryChannelsAsync(filters, _sortByCreatedAtAscending)).ToArray();
             Assert.Contains(channel1, channels);
             Assert.Contains(channel2, channels);
             Assert.Contains(channel3, channels);
-
-            // Query builder
-
-            var filters2 = new IFieldFilterRule[]
-            {
-                ChannelFilter.Cid.In(channel1, channel2, channel3)
-            };
-
-            var channels2 = (await Client.QueryChannelsAsync(filters2, _sortByCreatedAtAscending)).ToArray();
-            Assert.Contains(channel1, channels2);
-            Assert.Contains(channel2, channels2);
-            Assert.Contains(channel3, channels2);
         }
 
         [UnityTest]
@@ -70,43 +52,16 @@ namespace StreamChat.Tests.StatefulClient
 
             await channel2.HideAsync();
 
-            var filters = new Dictionary<string, object>
+            var filters = new IFieldFilterRule[]
             {
-                {
-                    "cid", new Dictionary<string, object>
-                    {
-                        {
-                            "$in", new[] { channel1.Cid, channel2.Cid, channel3.Cid }
-                        }
-                    }
-                },
-                {
-                    "hidden", new Dictionary<string, object>
-                    {
-                        {
-                            "$eq", false
-                        }
-                    }
-                }
+                ChannelFilter.Cid.In(channel1, channel2, channel3),
+                ChannelFilter.Hidden.EqualsTo(false),
             };
 
             var channels = (await Client.QueryChannelsAsync(filters, _sortByCreatedAtAscending)).ToArray();
             Assert.Contains(channel1, channels);
             Assert.IsNull(channels.FirstOrDefault(c => c == channel2));
             Assert.Contains(channel3, channels);
-
-            // Query builder
-
-            var filters2 = new IFieldFilterRule[]
-            {
-                ChannelFilter.Cid.In(channel1, channel2, channel3),
-                ChannelFilter.Hidden.EqualsTo(false),
-            };
-
-            var channels2 = (await Client.QueryChannelsAsync(filters2, _sortByCreatedAtAscending)).ToArray();
-            Assert.Contains(channel1, channels2);
-            Assert.IsNull(channels2.FirstOrDefault(c => c == channel2));
-            Assert.Contains(channel3, channels2);
         }
 
         [UnityTest]
@@ -130,52 +85,17 @@ namespace StreamChat.Tests.StatefulClient
 
             Assert.AreEqual(true, channel3.Frozen);
 
-            var filters = new Dictionary<string, object>
-            {
-                {
-                    "cid", new Dictionary<string, object>
-                    {
-                        {
-                            "$in", new[] { channel1.Cid, channel2.Cid, channel3.Cid }
-                        }
-                    }
-                },
-                {
-                    "hidden", new Dictionary<string, object>
-                    {
-                        {
-                            "$eq", false
-                        }
-                    }
-                },
-                {
-                    "frozen", new Dictionary<string, object>
-                    {
-                        {
-                            "$eq", false
-                        }
-                    }
-                }
-            };
-
-            var channels = (await Client.QueryChannelsAsync(filters, _sortByCreatedAtAscending)).ToArray();
-            Assert.Contains(channel1, channels);
-            Assert.IsNull(channels.FirstOrDefault(c => c == channel2));
-            Assert.IsNull(channels.FirstOrDefault(c => c == channel3));
-
-            // Query builder
-
-            var filters2 = new IFieldFilterRule[]
+            var filters = new IFieldFilterRule[]
             {
                 ChannelFilter.Cid.In(channel1, channel2, channel3),
                 ChannelFilter.Hidden.EqualsTo(false),
                 ChannelFilter.Frozen.EqualsTo(false),
             };
 
-            var channels2 = (await Client.QueryChannelsAsync(filters2, _sortByCreatedAtAscending)).ToArray();
-            Assert.Contains(channel1, channels2);
-            Assert.IsNull(channels2.FirstOrDefault(c => c == channel2));
-            Assert.IsNull(channels2.FirstOrDefault(c => c == channel3));
+            var channels = (await Client.QueryChannelsAsync(filters, _sortByCreatedAtAscending)).ToArray();
+            Assert.Contains(channel1, channels);
+            Assert.IsNull(channels.FirstOrDefault(c => c == channel2));
+            Assert.IsNull(channels.FirstOrDefault(c => c == channel3));
         }
 
         [UnityTest]
@@ -188,34 +108,15 @@ namespace StreamChat.Tests.StatefulClient
             var channel2 = await CreateUniqueTempChannelAsync();
             var channel3 = await CreateUniqueTempChannelAsync();
 
-            var filters = new Dictionary<string, object>
+            var filters = new IFieldFilterRule[]
             {
-                {
-                    "created_by_id", new Dictionary<string, object>
-                    {
-                        {
-                            "$eq", Client.LocalUserData.UserId
-                        }
-                    }
-                },
+                ChannelFilter.CreatedById.EqualsTo(Client.LocalUserData.User),
             };
 
             var channels = (await Client.QueryChannelsAsync(filters, _sortByCreatedAtAscending)).ToArray();
             Assert.Contains(channel1, channels);
             Assert.Contains(channel2, channels);
             Assert.Contains(channel3, channels);
-
-            // Query builder
-
-            var filters2 = new IFieldFilterRule[]
-            {
-                ChannelFilter.CreatedById.EqualsTo(Client.LocalUserData.User),
-            };
-
-            var channels2 = (await Client.QueryChannelsAsync(filters2, _sortByCreatedAtAscending)).ToArray();
-            Assert.Contains(channel1, channels2);
-            Assert.Contains(channel2, channels2);
-            Assert.Contains(channel3, channels2);
         }
 
         [UnityTest]
@@ -230,34 +131,15 @@ namespace StreamChat.Tests.StatefulClient
 
             await channel2.MuteChannelAsync();
 
-            var filters = new Dictionary<string, object>
+            var filters = new IFieldFilterRule[]
             {
-                {
-                    "muted", new Dictionary<string, object>
-                    {
-                        {
-                            "$eq", true
-                        }
-                    }
-                },
+                ChannelFilter.Muted.EqualsTo(true),
             };
 
             var channels = (await Client.QueryChannelsAsync(filters, _sortByCreatedAtAscending)).ToArray();
             Assert.IsNull(channels.FirstOrDefault(c => c == channel1));
             Assert.Contains(channel2, channels);
             Assert.IsNull(channels.FirstOrDefault(c => c == channel3));
-
-            // Query builder
-
-            var filters2 = new IFieldFilterRule[]
-            {
-                ChannelFilter.Muted.EqualsTo(true),
-            };
-
-            var channels2 = (await Client.QueryChannelsAsync(filters2, _sortByCreatedAtAscending)).ToArray();
-            Assert.IsNull(channels2.FirstOrDefault(c => c == channel1));
-            Assert.Contains(channel2, channels2);
-            Assert.IsNull(channels2.FirstOrDefault(c => c == channel3));
         }
 
         //StreamTodo: Uncomment this when `member.user.name` filtering is resolved
@@ -279,20 +161,20 @@ namespace StreamChat.Tests.StatefulClient
             await channel2.AddMembersAsync(userDaniel);
             await channel3.AddMembersAsync(userJonathan);
 
-            var filters = new Dictionary<string, object>
-            {
-                {
-                    "member.user.name", new Dictionary<string, object>
-                    {
-                        {
-                            "$autocomplete", "Daniel"
-                        }
-                    }
-                },
-            };
-
-            var channels = (await Client.QueryChannelsAsync(filters, _sortByCreatedAtAscending)).ToArray();
-            Assert.Contains(channel2, channels);
+            // var filters = new Dictionary<string, object>
+            // {
+            //     {
+            //         "member.user.name", new Dictionary<string, object>
+            //         {
+            //             {
+            //                 "$autocomplete", "Daniel"
+            //             }
+            //         }
+            //     },
+            // };
+            //
+            // var channels = (await Client.QueryChannelsAsync(filters, _sortByCreatedAtAscending)).ToArray();
+            // Assert.Contains(channel2, channels);
 
             // Query builder
 
@@ -323,16 +205,9 @@ namespace StreamChat.Tests.StatefulClient
             await channel2.AddMembersAsync(userDaniel);
             await channel2.AddMembersAsync(userJonathan);
 
-            var filters = new Dictionary<string, object>
+            var filters = new IFieldFilterRule[]
             {
-                {
-                    "member_count", new Dictionary<string, object>
-                    {
-                        {
-                            "$eq", 3
-                        }
-                    }
-                },
+                ChannelFilter.MembersCount.EqualsTo(3),
             };
 
             var channels = (await Client.QueryChannelsAsync(filters, _sortByCreatedAtAscending)).ToArray();
@@ -341,23 +216,10 @@ namespace StreamChat.Tests.StatefulClient
             Assert.IsNull(channels.FirstOrDefault(c => c == channel3));
             
             Assert.IsTrue(channels.All(c => c.MemberCount == 3));
-
-            // Query builder
-
-            var filters2 = new IFieldFilterRule[]
-            {
-                ChannelFilter.MembersCount.EqualsTo(3),
-            };
-
-            var channels2 = (await Client.QueryChannelsAsync(filters2, _sortByCreatedAtAscending)).ToArray();
-            Assert.IsNull(channels2.FirstOrDefault(c => c == channel1));
-            Assert.Contains(channel2, channels2);
-            Assert.IsNull(channels2.FirstOrDefault(c => c == channel3));
-            
-            Assert.IsTrue(channels2.All(c => c.MemberCount == 3));
         }
 
         private readonly ChannelSortObject _sortByCreatedAtAscending
             = ChannelSort.OrderByDescending(ChannelSortFieldName.CreatedAt);
     }
 }
+#endif

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQueryFiltersTests.cs.meta
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQueryFiltersTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 801432436fa742dba8e4c96afa554623
+timeCreated: 1674036742

--- a/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQuerySortTests.cs
+++ b/Assets/Plugins/StreamChat/Tests/StatefulClient/ChannelsQuerySortTests.cs
@@ -1,17 +1,18 @@
 ﻿#if STREAM_TESTS_ENABLED
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using StreamChat.Core;
+using StreamChat.Core.QueryBuilders.Filters;
+using StreamChat.Core.QueryBuilders.Filters.Channels;
 using StreamChat.Core.QueryBuilders.Sort;
 using UnityEngine.TestTools;
 
 namespace StreamChat.Tests.StatefulClient
 {
     /// <summary>
-    /// Tests for <see cref="IStreamChatClient.QueryChannelsAsync(System.Collections.Generic.IDictionary{string,object},ChannelSortObject,int,int)"/>
+    /// Tests for <see cref="IStreamChatClient.QueryChannelsAsync"/>
     /// </summary>
     internal class ChannelsQuerySortTests : BaseStateIntegrationTests
     {
@@ -26,19 +27,14 @@ namespace StreamChat.Tests.StatefulClient
             var channel3 = await CreateUniqueTempChannelAsync();
             var channel4 = await CreateUniqueTempChannelAsync();
 
-            var filter = new Dictionary<string, object>
+            var filters = new IFieldFilterRule[]
             {
-                {
-                    "cid", new Dictionary<string, object>
-                    {
-                        { "$in", new List<string> { channel.Cid, channel2.Cid, channel3.Cid, channel4.Cid } }
-                    }
-                }
+                ChannelFilter.Cid.In(channel.Cid, channel2.Cid, channel3.Cid, channel4.Cid)
             };
 
             var sort = ChannelSort.OrderByDescending(ChannelSortFieldName.CreatedAt);
 
-            var channels = await Client.QueryChannelsAsync(filter, sort);
+            var channels = await Client.QueryChannelsAsync(filters, sort);
             Assert.NotNull(channels);
             Assert.AreEqual(4, channels.Count());
             Assert.IsTrue(channels.SequenceEqual(new[] { channel4, channel3, channel2, channel }));
@@ -73,20 +69,15 @@ namespace StreamChat.Tests.StatefulClient
             await channel2.AddMembersAsync(TestAdminId);
             await channel4.AddMembersAsync(TestAdminId);
 
-            var filter = new Dictionary<string, object>
+            var filters = new IFieldFilterRule[]
             {
-                {
-                    "cid", new Dictionary<string, object>
-                    {
-                        { "$in", new List<string> { channel1.Cid, channel2.Cid, channel3.Cid, channel4.Cid } }
-                    }
-                }
+                ChannelFilter.Cid.In(channel1.Cid, channel2.Cid, channel3.Cid, channel4.Cid)
             };
 
             var sort = ChannelSort.OrderByDescending(ChannelSortFieldName.MemberCount)
                 .ThenByDescending(ChannelSortFieldName.CreatedAt);
 
-            var channels = await Client.QueryChannelsAsync(filter, sort);
+            var channels = await Client.QueryChannelsAsync(filters, sort);
             Assert.NotNull(channels);
             Assert.AreEqual(4, channels.Count());
             Assert.IsTrue(channels.SequenceEqual(new[] { channel3, channel1, channel4, channel2 }));

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -686,7 +686,7 @@ PlayerSettings:
   webGLThreadsSupport: 0
   webGLDecompressionFallback: 0
   scriptingDefineSymbols:
-    1: STREAM_TESTS_ENABLED
+    1: 
   additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend:


### PR DESCRIPTION
Filters for channels querying via `IStreamChatClient.QueryChannelsAsync` can now be created with a syntax based builder.

1. `QueryChannelsAsync` now accepts `IEnumerable<IFieldFilterRule> filters` parameter
2. Each field filter can be constructed with the help of `ChannelFilter`. It exposes all of the fields by which you can filter query. Once you pick a field it will expose all of the available operators for a particular field.

#Some examples:

### Get channels with ANY of the provided `Cid`'s 
```csharp
var filters = new IFieldFilterRule[]
{
   ChannelFilter.Cid.In("channel-cid", "channel-2-cid", "channel-3-cid")
};
var sort = ChannelSort.OrderByAscending(ChannelSortFieldName.CreatedAt);

var channels = await Client.QueryChannelsAsync(filters, sort);
```

Each operator usually accepts multiple argument types to match your needs:
```csharp
ChannelFilter.Cid.EqualsTo("channel-cid"); // string
ChannelFilter.Cid.EqualsTo(channel); // IStreamChannel
ChannelFilter.Cid.In("channel-cid", "channel-2-cid", "channel-3-cid"); // Comma separated strings

var channelCids = new List<string> { "channel-1-cid", "channel-2-cid" };
ChannelFilter.Cid.In(channelCids); // List or Array of strings
```
### Get channels where the local user is a member
```csharp
var filters = new IFieldFilterRule[]
{
   ChannelFilter.Members.In(Client.LocalUserData.User)
};
```
### Get channels created by the local user
```csharp
var filters = new IFieldFilterRule[]
{
   ChannelFilter.CreatedById.EqualsTo(Client.LocalUserData.User)
};
```
### Get channels muted by the local users
```csharp
var filters = new IFieldFilterRule[]
{
   ChannelFilter.Muted.EqualsTo(true)
};
```
### Get channels with more than 10 members
```csharp
var filters = new IFieldFilterRule[]
{
   ChannelFilter.MembersCount.GreaterThan(10)
};
```
### Get channels created within last week
```csharp
var weekAgo = DateTime.Now.AddDays(-7).Date;
var filters = new IFieldFilterRule[]
{
   ChannelFilter.CreatedAt.GreaterThan(weekAgo)
};
```
### Get channels updated within last 24 hours
```csharp
var dayAgo = DateTime.Now.AddHours(-24);
var filters = new IFieldFilterRule[]
{
   ChannelFilter.UpdatedAt.GreaterThan(dayAgo)
};
```
All available fields:
![image](https://user-images.githubusercontent.com/33436839/214318546-464a9e5d-ac1a-4dfb-b661-cc9de24d7033.png)



			