### PR TITLE
Feature/improve performance

### DIFF
--- a/Assets/Plugins/StreamChat/Core/Configs/IStreamClientConfig.cs
+++ b/Assets/Plugins/StreamChat/Core/Configs/IStreamClientConfig.cs
@@ -8,7 +8,11 @@ namespace StreamChat.Core.Configs
     public interface IStreamClientConfig
     {
         /// <summary>
-        /// What type of logs are being emitted.
+        /// What type of logs are being emitted. Available options:
+        /// FailureOnly - only errors will be logged. This option is recommended for production
+        /// All - all errors will be logged. This can be useful during development
+        /// Debug - This included All logs + some additional that can be useful for debugging
+        /// Disabled - no logs will be emitted. Not recommended in general - this could be only viable if you're capturing all of the thrown exceptions and handling the logging on your own.
         /// </summary>
         StreamLogLevel LogLevel { get; set; }
     }

--- a/Assets/Plugins/StreamChat/Core/Configs/StreamClientConfig.cs
+++ b/Assets/Plugins/StreamChat/Core/Configs/StreamClientConfig.cs
@@ -7,6 +7,6 @@
     {
         public static IStreamClientConfig Default { get; set; } = new StreamClientConfig();
 
-        public StreamLogLevel LogLevel { get; set; } = StreamLogLevel.All;
+        public StreamLogLevel LogLevel { get; set; } = StreamLogLevel.FailureOnly;
     }
 }

--- a/Assets/Plugins/StreamChat/Libs/Websockets/WebsocketClient.cs
+++ b/Assets/Plugins/StreamChat/Libs/Websockets/WebsocketClient.cs
@@ -77,8 +77,8 @@ namespace StreamChat.Libs.Websockets
                 return;
             }
 
-            _backgroundSendTimer = new Timer(SendMessagesCallback, null, 0, 100);
-            _backgroundReceiveTimer = new Timer(ReceiveMessagesCallback, null, 50, 100);
+            _backgroundSendTimer = new Timer(SendMessagesCallback, null, 0, UpdatePeriod);
+            _backgroundReceiveTimer = new Timer(ReceiveMessagesCallback, null, UpdatePeriodOffset, UpdatePeriod);
 
             Connected?.Invoke();
         }
@@ -128,6 +128,10 @@ namespace StreamChat.Libs.Websockets
             DisconnectAsync(WebSocketCloseStatus.NormalClosure, "WebSocket client is disposed")
                 .ContinueWith(_ => LogExceptionIfDebugMode(_.Exception), TaskContinuationOptions.OnlyOnFaulted);
         }
+        
+        private const int UpdatesPerSecond = 20;
+        private const int UpdatePeriod = 1000 / UpdatesPerSecond;
+        private const int UpdatePeriodOffset = UpdatePeriod / 2;
 
         private static Encoding DefaultEncoding { get; } = Encoding.UTF8;
 

--- a/Assets/Plugins/StreamChat/Libs/Websockets/WebsocketClient.cs
+++ b/Assets/Plugins/StreamChat/Libs/Websockets/WebsocketClient.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using StreamChat.Libs.Logs;
-using UnityEngine.Profiling;
 
 namespace StreamChat.Libs.Websockets
 {
@@ -149,13 +148,13 @@ namespace StreamChat.Libs.Websockets
         private readonly ILogs _logs;
         private readonly Encoding _encoding;
         private readonly bool _isDebugMode;
-        
+
         private readonly SemaphoreSlim _backgroundSendSemaphore = new SemaphoreSlim(1);
         private readonly SemaphoreSlim _backgroundReceiveSemaphore = new SemaphoreSlim(1);
 
         private Timer _backgroundSendTimer;
         private Timer _backgroundReceiveTimer;
-        
+
         private Uri _uri;
         private ClientWebSocket _internalClient;
         private CancellationTokenSource _connectionCts;
@@ -172,7 +171,6 @@ namespace StreamChat.Libs.Websockets
                 return;
             }
 
-            Profiler.BeginSample("StreamBackgroundTask");
             try
             {
                 while (_sendQueue.TryTake(out var msg))
@@ -200,8 +198,6 @@ namespace StreamChat.Libs.Websockets
             {
                 _backgroundSendSemaphore.Release();
             }
-
-            Profiler.EndSample();
         }
 
         // Runs on a background thread
@@ -211,13 +207,12 @@ namespace StreamChat.Libs.Websockets
             {
                 return;
             }
-            
+
             if (!_backgroundReceiveSemaphore.Wait(0))
             {
                 return;
             }
 
-            Profiler.BeginSample("StreamBackgroundTask");
             try
             {
                 var result = await TryReceiveSingleMessageAsync();
@@ -243,8 +238,6 @@ namespace StreamChat.Libs.Websockets
             {
                 _backgroundReceiveSemaphore.Release();
             }
-
-            Profiler.EndSample();
         }
 
         private async Task TryDisposeResourcesAsync(WebSocketCloseStatus closeStatus, string closeMessage)


### PR DESCRIPTION
Refactor WS implementation to use a `Thread Timer` instead of the infinite `async/await` loop in order to reduce the per-frame overhead and reduce the CPU usage + set a max 20x per second WS send/receive frames which should suffice to create a realtime user experience without causing excessive CPU usage