### PR TITLE
Feature/potential fix for android il2cpp crash

### DIFF
--- a/Assets/Plugins/StreamChat/Core/Helpers/ICollectionExt.cs
+++ b/Assets/Plugins/StreamChat/Core/Helpers/ICollectionExt.cs
@@ -23,6 +23,10 @@ namespace StreamChat.Core.Helpers
 
             foreach (var item in source)
             {
+                if (item == null)
+                {
+                    continue;
+                }
                 dtos.Add(item.SaveToDto());
             }
 

--- a/Assets/Plugins/StreamChat/Core/Helpers/IDictionaryExt.cs
+++ b/Assets/Plugins/StreamChat/Core/Helpers/IDictionaryExt.cs
@@ -20,6 +20,11 @@ namespace StreamChat.Core.Helpers
 
             foreach (var sourceKeyValue in source)
             {
+                if (sourceKeyValue.Value == null)
+                {
+                    continue;
+                }
+
                 dict.Add(sourceKeyValue.Key, sourceKeyValue.Value.SaveToDto());
             }
 
@@ -39,6 +44,11 @@ namespace StreamChat.Core.Helpers
 
             foreach (var sourceKeyValue in dtos)
             {
+                if (sourceKeyValue.Value == null)
+                {
+                    continue;
+                }
+
                 dict.Add(sourceKeyValue.Key, new TSource().LoadFromDto(sourceKeyValue.Value));
             }
 

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/UpdateUsersRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/UpdateUsersRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using StreamChat.Core.Helpers;
 using StreamChat.Core.InternalDTO.Requests;
 
 namespace StreamChat.Core.LowLevelClient.Requests
@@ -15,10 +16,12 @@ namespace StreamChat.Core.LowLevelClient.Requests
         {
             var dto = new UpdateUsersRequestInternalDTO
             {
+                // Users = Users.TrySaveToDtoDictionary<UserObjectRequestInternalDTO, UserObjectRequest, string>(),
                 AdditionalProperties = AdditionalProperties,
             };
 
             // Ticket#38178 TrySaveToDtoDictionary caused crashes on old Android versions with IL2CPP
+            // Perhaps this due to IL2CPP not handling well complex generic signatures
             if (Users != null)
             {
                 var dict = new Dictionary<string, UserObjectRequestInternalDTO>();
@@ -29,9 +32,13 @@ namespace StreamChat.Core.LowLevelClient.Requests
                     {
                         continue;
                     }
-                    
-                    dict.Add(sourceKeyValue.Key,
-                        ((ISavableTo<UserObjectRequestInternalDTO>)sourceKeyValue.Value).SaveToDto());
+
+                    var serialized = sourceKeyValue.Value.TrySaveToDto();
+
+                    if (serialized != null)
+                    {
+                        dict.Add(sourceKeyValue.Key,serialized);
+                    }
                 }
             
                 dto.Users = dict;

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/UpdateUsersRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/UpdateUsersRequest.cs
@@ -1,4 +1,4 @@
-﻿using StreamChat.Core.Helpers;
+﻿using System.Collections.Generic;
 using StreamChat.Core.InternalDTO.Requests;
 
 namespace StreamChat.Core.LowLevelClient.Requests
@@ -11,11 +11,33 @@ namespace StreamChat.Core.LowLevelClient.Requests
         /// StreamTodo: Check if this could be list
         public System.Collections.Generic.Dictionary<string, UserObjectRequest> Users { get; set; }
 
-        UpdateUsersRequestInternalDTO ISavableTo<UpdateUsersRequestInternalDTO>.SaveToDto() =>
-            new UpdateUsersRequestInternalDTO
+        UpdateUsersRequestInternalDTO ISavableTo<UpdateUsersRequestInternalDTO>.SaveToDto()
+        {
+            var dto = new UpdateUsersRequestInternalDTO
             {
-                Users = Users.TrySaveToDtoDictionary<UserObjectRequestInternalDTO, UserObjectRequest, string>(),
                 AdditionalProperties = AdditionalProperties,
             };
+
+            // Ticket#38178 TrySaveToDtoDictionary caused crashes on old Android versions with IL2CPP
+            if (Users != null)
+            {
+                var dict = new Dictionary<string, UserObjectRequestInternalDTO>();
+            
+                foreach (var sourceKeyValue in Users)
+                {
+                    if (sourceKeyValue.Value == null)
+                    {
+                        continue;
+                    }
+                    
+                    dict.Add(sourceKeyValue.Key,
+                        ((ISavableTo<UserObjectRequestInternalDTO>)sourceKeyValue.Value).SaveToDto());
+                }
+            
+                dto.Users = dict;
+            }
+
+            return dto;
+        }
     }
 }


### PR DESCRIPTION
Simplify code that used a generic extension. The `TrySaveToDtoDictionary` was reported to crash in IL2CPP on some older Android versions. I wasn't able to reproduce the crash but code simplification will not hurt and might do the trick. 