### PR TITLE
Fix role deserialization.

### DIFF
--- a/Assets/Plugins/StreamChat/Core/InternalDTO/Models/ChannelMemberInternalDTO.cs
+++ b/Assets/Plugins/StreamChat/Core/InternalDTO/Models/ChannelMemberInternalDTO.cs
@@ -71,8 +71,7 @@ namespace StreamChat.Core.InternalDTO.Models
         /// Permission level of the member in the channel (DEPRECATED: use channel_role instead)
         /// </summary>
         [Newtonsoft.Json.JsonProperty("role", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public ChannelMemberRoleType? Role { get; set; }
+        public string Role { get; set; }
 
         /// <summary>
         /// Whether member is shadow banned in this channel or not

--- a/Assets/Plugins/StreamChat/Core/InternalDTO/Requests/ChannelMemberRequestInternalDTO.cs
+++ b/Assets/Plugins/StreamChat/Core/InternalDTO/Requests/ChannelMemberRequestInternalDTO.cs
@@ -71,8 +71,7 @@ namespace StreamChat.Core.InternalDTO.Requests
         /// Permission level of the member in the channel (DEPRECATED: use channel_role instead)
         /// </summary>
         [Newtonsoft.Json.JsonProperty("role", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public ChannelMemberRoleType? Role { get; set; }
+        public string Role { get; set; }
 
         /// <summary>
         /// Whether member is shadow banned in this channel or not

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/ChannelMember.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/ChannelMember.cs
@@ -52,7 +52,7 @@ namespace StreamChat.Core.LowLevelClient.Models
         /// Permission level of the member in the channel (DEPRECATED: use channel_role instead)
         /// </summary>
         [Obsolete("Use ChannelRole instead")]
-        public ChannelMemberRoleType? Role { get; set; }
+        public string Role { get; set; }
 
         /// <summary>
         /// Whether member is shadow banned in this channel or not

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/ChannelMemberRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/ChannelMemberRequest.cs
@@ -1,4 +1,5 @@
-﻿using StreamChat.Core.Helpers;
+﻿using System;
+using StreamChat.Core.Helpers;
 using StreamChat.Core.InternalDTO.Models;
 using StreamChat.Core.InternalDTO.Requests;
 
@@ -51,7 +52,8 @@ namespace StreamChat.Core.LowLevelClient.Requests
         /// <summary>
         /// Permission level of the member in the channel (DEPRECATED: use channel_role instead)
         /// </summary>
-        public ChannelMemberRoleType? Role { get; set; }
+        [Obsolete("Use ChannelRole instead")]
+        public string Role { get; set; }
 
         /// <summary>
         /// Whether member is shadow banned in this channel or not


### PR DESCRIPTION
The `ChannelMemberRoleType` enum is missing values. Note: Role is deprecated, so we can just switch it to string to avoid deserialization issues