### PR TITLE
Fix IL2CPP build crash on Unity 6000.0.x caused by multiple implement…

### DIFF
--- a/Assets/Plugins/StreamChat/Core/Helpers/ICollectionExt.cs
+++ b/Assets/Plugins/StreamChat/Core/Helpers/ICollectionExt.cs
@@ -69,8 +69,88 @@ namespace StreamChat.Core.Helpers
         }
 
         [Pure]
+        public static List<TDto> TrySaveToDtoCollection2<TSource, TDto>(this List<TSource> source)
+            where TSource : ISavableTo2<TDto>
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            var dtos = new List<TDto>(source.Count);
+
+            foreach (var item in source)
+            {
+                if (item == null)
+                {
+                    continue;
+                }
+                dtos.Add(item.SaveToDto());
+            }
+
+            return dtos;
+        }
+
+        [Pure]
         public static List<TSource> TryLoadFromDtoCollection<TDto, TSource>(this List<TSource> _, List<TDto> dtos)
             where TSource : ILoadableFrom<TDto, TSource>, new()
+        {
+            if (dtos == null)
+            {
+                return null;
+            }
+
+            var items = new List<TSource>(dtos.Count);
+
+            foreach (var dto in dtos)
+            {
+                items.Add(new TSource().LoadFromDto(dto));
+            }
+
+            return items;
+        }
+
+        [Pure]
+        public static List<TSource> TryLoadFromDtoCollection2<TDto, TSource>(this List<TSource> _, List<TDto> dtos)
+            where TSource : ILoadableFrom2<TDto, TSource>, new()
+        {
+            if (dtos == null)
+            {
+                return null;
+            }
+
+            var items = new List<TSource>(dtos.Count);
+
+            foreach (var dto in dtos)
+            {
+                items.Add(new TSource().LoadFromDto(dto));
+            }
+
+            return items;
+        }
+
+        [Pure]
+        public static List<TSource> TryLoadFromDtoCollection3<TDto, TSource>(this List<TSource> _, List<TDto> dtos)
+            where TSource : ILoadableFrom3<TDto, TSource>, new()
+        {
+            if (dtos == null)
+            {
+                return null;
+            }
+
+            var items = new List<TSource>(dtos.Count);
+
+            foreach (var dto in dtos)
+            {
+                items.Add(new TSource().LoadFromDto(dto));
+            }
+
+            return items;
+        }
+
+        [Pure]
+        public static List<TSource> TryLoadFromDtoCollection4<TDto, TSource>(this List<TSource> _, List<TDto> dtos)
+            where TSource : ILoadableFrom4<TDto, TSource>, new()
         {
             if (dtos == null)
             {

--- a/Assets/Plugins/StreamChat/Core/Helpers/IDictionaryExt.cs
+++ b/Assets/Plugins/StreamChat/Core/Helpers/IDictionaryExt.cs
@@ -54,5 +54,29 @@ namespace StreamChat.Core.Helpers
 
             return dict;
         }
+
+        public static Dictionary<TKey, TSource> TryLoadFromDtoDictionary4<TDto, TSource, TKey>(
+            this Dictionary<TKey, TSource> _, Dictionary<TKey, TDto> dtos)
+            where TSource : ILoadableFrom4<TDto, TSource>, new()
+        {
+            if (dtos == null)
+            {
+                return null;
+            }
+
+            var dict = new Dictionary<TKey, TSource>();
+
+            foreach (var sourceKeyValue in dtos)
+            {
+                if (sourceKeyValue.Value == null)
+                {
+                    continue;
+                }
+
+                dict.Add(sourceKeyValue.Key, new TSource().LoadFromDto(sourceKeyValue.Value));
+            }
+
+            return dict;
+        }
     }
 }

--- a/Assets/Plugins/StreamChat/Core/Helpers/ILoadableFromExt.cs
+++ b/Assets/Plugins/StreamChat/Core/Helpers/ILoadableFromExt.cs
@@ -49,5 +49,119 @@ namespace StreamChat.Core.Helpers
 
             return new TDomain().LoadFromDto(dto);
         }
+
+        public static TDomain TryLoadFromDto<TDto, TDomain>(this ILoadableFrom2<TDto, TDomain> loadable, TDto dto)
+            where TDomain : ILoadableFrom2<TDto, TDomain>, new()
+        {
+            if (dto == null)
+            {
+                return default;
+            }
+
+            return loadable != null ? loadable.LoadFromDto(dto) : new TDomain().LoadFromDto(dto);
+        }
+
+        public static TDomain UpdateFromDto<TDto, TDomain>(this ILoadableFrom2<TDto, TDomain> loadable, TDto dto)
+            where TDomain : ILoadableFrom2<TDto, TDomain>, new()
+        {
+            if (dto == null)
+            {
+                return default;
+            }
+
+            if (loadable == null)
+            {
+                throw new ArgumentException(nameof(loadable));
+            }
+
+            return loadable.LoadFromDto(dto);
+        }
+
+        public static TDomain ToDomain2<TDto, TDomain>(this TDto dto)
+            where TDomain : class, ILoadableFrom2<TDto, TDomain>, new()
+        {
+            if (dto == null)
+            {
+                return null;
+            }
+
+            return new TDomain().LoadFromDto(dto);
+        }
+
+        public static TDomain TryLoadFromDto<TDto, TDomain>(this ILoadableFrom3<TDto, TDomain> loadable, TDto dto)
+            where TDomain : ILoadableFrom3<TDto, TDomain>, new()
+        {
+            if (dto == null)
+            {
+                return default;
+            }
+
+            return loadable != null ? loadable.LoadFromDto(dto) : new TDomain().LoadFromDto(dto);
+        }
+
+        public static TDomain UpdateFromDto<TDto, TDomain>(this ILoadableFrom3<TDto, TDomain> loadable, TDto dto)
+            where TDomain : ILoadableFrom3<TDto, TDomain>, new()
+        {
+            if (dto == null)
+            {
+                return default;
+            }
+
+            if (loadable == null)
+            {
+                throw new ArgumentException(nameof(loadable));
+            }
+
+            return loadable.LoadFromDto(dto);
+        }
+
+        public static TDomain ToDomain3<TDto, TDomain>(this TDto dto)
+            where TDomain : class, ILoadableFrom3<TDto, TDomain>, new()
+        {
+            if (dto == null)
+            {
+                return null;
+            }
+
+            return new TDomain().LoadFromDto(dto);
+        }
+
+        public static TDomain TryLoadFromDto<TDto, TDomain>(this ILoadableFrom4<TDto, TDomain> loadable, TDto dto)
+            where TDomain : ILoadableFrom4<TDto, TDomain>, new()
+        {
+            if (dto == null)
+            {
+                return default;
+            }
+
+            return loadable != null ? loadable.LoadFromDto(dto) : new TDomain().LoadFromDto(dto);
+        }
+
+        public static TDomain UpdateFromDto<TDto, TDomain>(this ILoadableFrom4<TDto, TDomain> loadable, TDto dto)
+            where TDomain : ILoadableFrom4<TDto, TDomain>, new()
+        {
+            if (dto == null)
+            {
+                return default;
+            }
+
+            if (loadable == null)
+            {
+                throw new ArgumentException(nameof(loadable));
+            }
+
+            return loadable.LoadFromDto(dto);
+        }
+
+        public static TDomain ToDomain4<TDto, TDomain>(this TDto dto)
+            where TDomain : class, ILoadableFrom4<TDto, TDomain>, new()
+        {
+            if (dto == null)
+            {
+                return null;
+            }
+
+            return new TDomain().LoadFromDto(dto);
+        }
     }
 }

--- a/Assets/Plugins/StreamChat/Core/Helpers/ISavableToExt.cs
+++ b/Assets/Plugins/StreamChat/Core/Helpers/ISavableToExt.cs
@@ -9,5 +9,11 @@ namespace StreamChat.Core.Helpers
     {
         public static TDto TrySaveToDto<TDto>(this ISavableTo<TDto> source)
             => source != default ? source.SaveToDto() : default;
+
+        public static TDto TrySaveToDto<TDto>(this ISavableTo2<TDto> source)
+            => source != default ? source.SaveToDto() : default;
+
+        public static TDto TrySaveToDto<TDto>(this ISavableTo3<TDto> source)
+            => source != default ? source.SaveToDto() : default;
     }
 }

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/API/ChannelApi.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/API/ChannelApi.cs
@@ -27,7 +27,7 @@ namespace StreamChat.Core.LowLevelClient.API
             ChannelGetOrCreateRequest getOrCreateRequest)
         {
             var dto = await _internalChannelApi.GetOrCreateChannelAsync(channelType, getOrCreateRequest.TrySaveToDto());
-            return dto.ToDomain<ChannelStateResponseInternalDTO, ChannelState>();
+            return dto.ToDomain2<ChannelStateResponseInternalDTO, ChannelState>();
         }
 
         public async Task<ChannelState> GetOrCreateChannelAsync(string channelType, string channelId,
@@ -35,7 +35,7 @@ namespace StreamChat.Core.LowLevelClient.API
         {
             var dto = await _internalChannelApi.GetOrCreateChannelAsync(channelType, channelId,
                 getOrCreateRequest.TrySaveToDto());
-            return dto.ToDomain<ChannelStateResponseInternalDTO, ChannelState>();
+            return dto.ToDomain2<ChannelStateResponseInternalDTO, ChannelState>();
         }
 
         public async Task<UpdateChannelResponse> UpdateChannelAsync(string channelType, string channelId,

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/ILoadableFrom.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/ILoadableFrom.cs
@@ -10,4 +10,22 @@
     {
         TDomain LoadFromDto(TDto dto);
     }
+
+    internal interface ILoadableFrom2<in TDto, out TDomain>
+        where TDomain : ILoadableFrom2<TDto, TDomain>
+    {
+        TDomain LoadFromDto(TDto dto);
+    }
+
+    internal interface ILoadableFrom3<in TDto, out TDomain>
+        where TDomain : ILoadableFrom3<TDto, TDomain>
+    {
+        TDomain LoadFromDto(TDto dto);
+    }
+
+    internal interface ILoadableFrom4<in TDto, out TDomain>
+        where TDomain : ILoadableFrom4<TDto, TDomain>
+    {
+        TDomain LoadFromDto(TDto dto);
+    }
 }

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/ISavableTo.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/ISavableTo.cs
@@ -8,4 +8,23 @@
     {
         TDto SaveToDto();
     }
+
+    /// <summary>
+    /// Secondary DTO save target. Identical to <see cref="ISavableTo{TDto}"/> but declared as a separate interface
+    /// to work around an IL2CPP vtable builder bug (Unity 6000.0.x) that crashes when a single type implements
+    /// multiple closed versions of the same generic interface.
+    /// </summary>
+    internal interface ISavableTo2<out TDto>
+    {
+        TDto SaveToDto();
+    }
+
+    /// <summary>
+    /// Tertiary DTO save target. Same workaround as <see cref="ISavableTo2{TDto}"/> for types that need
+    /// three distinct DTO conversions (e.g. <see cref="Requests.UserObjectRequest"/>).
+    /// </summary>
+    internal interface ISavableTo3<out TDto>
+    {
+        TDto SaveToDto();
+    }
 }

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/ChannelMember.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/ChannelMember.cs
@@ -6,7 +6,7 @@ using StreamChat.Core.InternalDTO.Responses;
 namespace StreamChat.Core.LowLevelClient.Models
 {
     public class ChannelMember : ModelBase, ILoadableFrom<ChannelMemberInternalDTO, ChannelMember>,
-        ILoadableFrom<ChannelMemberResponseInternalDTO, ChannelMember>, ISavableTo<ChannelMemberInternalDTO>
+        ILoadableFrom2<ChannelMemberResponseInternalDTO, ChannelMember>, ISavableTo<ChannelMemberInternalDTO>
     {
         /// <summary>
         /// Expiration date of the ban
@@ -91,7 +91,7 @@ namespace StreamChat.Core.LowLevelClient.Models
             return this;
         }
 
-        ChannelMember ILoadableFrom<ChannelMemberResponseInternalDTO, ChannelMember>.LoadFromDto(
+        ChannelMember ILoadableFrom2<ChannelMemberResponseInternalDTO, ChannelMember>.LoadFromDto(
             ChannelMemberResponseInternalDTO dto)
         {
             BanExpires = dto.BanExpires;

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/ChannelState.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/ChannelState.cs
@@ -8,7 +8,7 @@ using StreamChat.Core.InternalDTO.Responses;
 namespace StreamChat.Core.LowLevelClient.Models
 {
     public class ChannelState : ModelBase, ILoadableFrom<ChannelStateResponseFieldsInternalDTO, ChannelState>,
-        ILoadableFrom<ChannelStateResponseInternalDTO, ChannelState>
+        ILoadableFrom2<ChannelStateResponseInternalDTO, ChannelState>
     {
         [Obsolete("This event is deprecated and will be removed in a future major release.")]
         public event Action<ChannelState, Message> NewMessageAdded;
@@ -81,30 +81,30 @@ namespace StreamChat.Core.LowLevelClient.Models
             HideMessagesBefore = dto.HideMessagesBefore;
             Members = Members.TryLoadFromDtoCollection(dto.Members);
             Membership = Membership.TryLoadFromDto<ChannelMemberInternalDTO, ChannelMember>(dto.Membership);
-            Messages = Messages.TryLoadFromDtoCollection(dto.Messages);
+            Messages = Messages.TryLoadFromDtoCollection3(dto.Messages);
             PendingMessages = PendingMessages.TryLoadFromDtoCollection(dto.PendingMessages);
-            PinnedMessages = PinnedMessages.TryLoadFromDtoCollection(dto.PinnedMessages);
+            PinnedMessages = PinnedMessages.TryLoadFromDtoCollection3(dto.PinnedMessages);
             Read = Read.TryLoadFromDtoCollection(dto.Read);
             WatcherCount = dto.WatcherCount;
-            Watchers = Watchers.TryLoadFromDtoCollection(dto.Watchers);
+            Watchers = Watchers.TryLoadFromDtoCollection2(dto.Watchers);
             AdditionalProperties = dto.AdditionalProperties;
 
             return this;
         }
 
-        ChannelState ILoadableFrom<ChannelStateResponseInternalDTO, ChannelState>.LoadFromDto(ChannelStateResponseInternalDTO dto)
+        ChannelState ILoadableFrom2<ChannelStateResponseInternalDTO, ChannelState>.LoadFromDto(ChannelStateResponseInternalDTO dto)
         {
             Channel = Channel.TryLoadFromDto(dto.Channel);
             Hidden = dto.Hidden;
             HideMessagesBefore = dto.HideMessagesBefore;
             Members = Members.TryLoadFromDtoCollection(dto.Members);
             Membership = Membership.TryLoadFromDto<ChannelMemberInternalDTO, ChannelMember>(dto.Membership);
-            Messages = Messages.TryLoadFromDtoCollection(dto.Messages);
+            Messages = Messages.TryLoadFromDtoCollection3(dto.Messages);
             PendingMessages = PendingMessages.TryLoadFromDtoCollection(dto.PendingMessages);
-            PinnedMessages = PinnedMessages.TryLoadFromDtoCollection(dto.PinnedMessages);
+            PinnedMessages = PinnedMessages.TryLoadFromDtoCollection3(dto.PinnedMessages);
             Read = Read.TryLoadFromDtoCollection(dto.Read);
             WatcherCount = dto.WatcherCount;
-            Watchers = Watchers.TryLoadFromDtoCollection(dto.Watchers);
+            Watchers = Watchers.TryLoadFromDtoCollection2(dto.Watchers);
             AdditionalProperties = dto.AdditionalProperties;
 
             return this;

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/Message.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/Message.cs
@@ -7,8 +7,8 @@ using StreamChat.Core.InternalDTO.Responses;
 namespace StreamChat.Core.LowLevelClient.Models
 {
     public class Message : ModelBase, ILoadableFrom<MessageInternalDTO, Message>, 
-        ILoadableFrom<SearchResultMessageInternalDTO, Message>, 
-        ILoadableFrom<MessageResponseInternalDTO, Message>
+        ILoadableFrom2<SearchResultMessageInternalDTO, Message>, 
+        ILoadableFrom3<MessageResponseInternalDTO, Message>
     {
         /// <summary>
         /// Array of message attachments
@@ -213,7 +213,7 @@ namespace StreamChat.Core.LowLevelClient.Models
             return this;
         }
 
-        Message ILoadableFrom<SearchResultMessageInternalDTO, Message>.LoadFromDto(SearchResultMessageInternalDTO dto)
+        Message ILoadableFrom2<SearchResultMessageInternalDTO, Message>.LoadFromDto(SearchResultMessageInternalDTO dto)
         {
             Attachments = Attachments.TryLoadFromDtoCollection(dto.Attachments);
             BeforeMessageSendFailed = dto.BeforeMessageSendFailed;
@@ -253,7 +253,7 @@ namespace StreamChat.Core.LowLevelClient.Models
             return this;
         }
         
-        Message ILoadableFrom<MessageResponseInternalDTO, Message>.LoadFromDto(MessageResponseInternalDTO dto)
+        Message ILoadableFrom3<MessageResponseInternalDTO, Message>.LoadFromDto(MessageResponseInternalDTO dto)
         {
             Attachments = Attachments.TryLoadFromDtoCollection(dto.Attachments);
             BeforeMessageSendFailed = dto.BeforeMessageSendFailed;
@@ -266,10 +266,10 @@ namespace StreamChat.Core.LowLevelClient.Models
             I18n = dto.I18n;
             Id = dto.Id;
             ImageLabels = dto.ImageLabels;
-            LatestReactions = LatestReactions.TryLoadFromDtoCollection(dto.LatestReactions);
-            MentionedUsers = MentionedUsers.TryLoadFromDtoCollection(dto.MentionedUsers);
+            LatestReactions = LatestReactions.TryLoadFromDtoCollection2(dto.LatestReactions);
+            MentionedUsers = MentionedUsers.TryLoadFromDtoCollection2(dto.MentionedUsers);
             Mml = dto.Mml;
-            OwnReactions = OwnReactions.TryLoadFromDtoCollection(dto.OwnReactions);
+            OwnReactions = OwnReactions.TryLoadFromDtoCollection2(dto.OwnReactions);
             ParentId = dto.ParentId;
             PinExpires = dto.PinExpires;
             Pinned = dto.Pinned;
@@ -284,7 +284,7 @@ namespace StreamChat.Core.LowLevelClient.Models
             ShowInChannel = dto.ShowInChannel;
             Silent = dto.Silent;
             Text = dto.Text;
-            ThreadParticipants = ThreadParticipants.TryLoadFromDtoCollection(dto.ThreadParticipants);
+            ThreadParticipants = ThreadParticipants.TryLoadFromDtoCollection2(dto.ThreadParticipants);
             Type = Type.TryLoadFromDto(dto.Type);
             UpdatedAt = dto.UpdatedAt;
             User = User.TryLoadFromDto<UserResponseInternalDTO, User>(dto.User);

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/Poll.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/Poll.cs
@@ -9,7 +9,7 @@ namespace StreamChat.Core.LowLevelClient.Models
     /// <summary>
     /// Represents a poll
     /// </summary>
-    public partial class Poll : ModelBase, ILoadableFrom<PollInternalDTO, Poll>, ILoadableFrom<PollResponseDataInternalDTO, Poll>
+    public partial class Poll : ModelBase, ILoadableFrom<PollInternalDTO, Poll>, ILoadableFrom2<PollResponseDataInternalDTO, Poll>
     {
         public bool AllowAnswers { get; set; }
 
@@ -81,7 +81,7 @@ namespace StreamChat.Core.LowLevelClient.Models
             return this;
         }
 
-        Poll ILoadableFrom<PollResponseDataInternalDTO, Poll>.LoadFromDto(PollResponseDataInternalDTO dto)
+        Poll ILoadableFrom2<PollResponseDataInternalDTO, Poll>.LoadFromDto(PollResponseDataInternalDTO dto)
         {
             AllowAnswers = dto.AllowAnswers;
             AllowUserSuggestedOptions = dto.AllowUserSuggestedOptions;
@@ -94,12 +94,12 @@ namespace StreamChat.Core.LowLevelClient.Models
             EnforceUniqueVote = dto.EnforceUniqueVote;
             Id = dto.Id;
             IsClosed = dto.IsClosed;
-            LatestAnswers = LatestAnswers.TryLoadFromDtoCollection(dto.LatestAnswers);
+            LatestAnswers = LatestAnswers.TryLoadFromDtoCollection2(dto.LatestAnswers);
             LatestVotesByOption = LoadVotesByOption(dto.LatestVotesByOption);
             MaxVotesAllowed = dto.MaxVotesAllowed;
             Name = dto.Name;
-            Options = Options.TryLoadFromDtoCollection(dto.Options);
-            OwnVotes = OwnVotes.TryLoadFromDtoCollection(dto.OwnVotes);
+            Options = Options.TryLoadFromDtoCollection2(dto.Options);
+            OwnVotes = OwnVotes.TryLoadFromDtoCollection2(dto.OwnVotes);
             UpdatedAt = dto.UpdatedAt;
             VoteCount = dto.VoteCount;
             VoteCountsByOption = dto.VoteCountsByOption;
@@ -119,7 +119,7 @@ namespace StreamChat.Core.LowLevelClient.Models
             var result = new Dictionary<string, List<PollVote>>();
             foreach (var kvp in dto)
             {
-                result[kvp.Key] = new List<PollVote>().TryLoadFromDtoCollection(kvp.Value);
+                result[kvp.Key] = new List<PollVote>().TryLoadFromDtoCollection2(kvp.Value);
             }
             return result;
         }

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/PollOption.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/PollOption.cs
@@ -9,7 +9,7 @@ namespace StreamChat.Core.LowLevelClient.Models
     /// <summary>
     /// Represents a poll option
     /// </summary>
-    public partial class PollOption : ILoadableFrom<PollOptionInternalDTO, PollOption>, ILoadableFrom<PollOptionResponseDataInternalDTO, PollOption>
+    public partial class PollOption : ILoadableFrom<PollOptionInternalDTO, PollOption>, ILoadableFrom2<PollOptionResponseDataInternalDTO, PollOption>
     {
         public Dictionary<string, object> Custom { get; set; }
 
@@ -29,7 +29,7 @@ namespace StreamChat.Core.LowLevelClient.Models
             return this;
         }
 
-        PollOption ILoadableFrom<PollOptionResponseDataInternalDTO, PollOption>.LoadFromDto(PollOptionResponseDataInternalDTO dto)
+        PollOption ILoadableFrom2<PollOptionResponseDataInternalDTO, PollOption>.LoadFromDto(PollOptionResponseDataInternalDTO dto)
         {
             Custom = dto.Custom;
             Id = dto.Id;

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/PollVote.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/PollVote.cs
@@ -9,7 +9,7 @@ namespace StreamChat.Core.LowLevelClient.Models
     /// <summary>
     /// Represents a poll vote
     /// </summary>
-    public partial class PollVote : ILoadableFrom<PollVoteInternalDTO, PollVote>, ILoadableFrom<PollVoteResponseDataInternalDTO, PollVote>
+    public partial class PollVote : ILoadableFrom<PollVoteInternalDTO, PollVote>, ILoadableFrom2<PollVoteResponseDataInternalDTO, PollVote>
     {
         public string AnswerText { get; set; }
 
@@ -47,7 +47,7 @@ namespace StreamChat.Core.LowLevelClient.Models
             return this;
         }
 
-        PollVote ILoadableFrom<PollVoteResponseDataInternalDTO, PollVote>.LoadFromDto(PollVoteResponseDataInternalDTO dto)
+        PollVote ILoadableFrom2<PollVoteResponseDataInternalDTO, PollVote>.LoadFromDto(PollVoteResponseDataInternalDTO dto)
         {
             AnswerText = dto.AnswerText;
             CreatedAt = dto.CreatedAt;

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/PushNotificationSettings.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/PushNotificationSettings.cs
@@ -7,9 +7,9 @@ namespace StreamChat.Core.LowLevelClient.Models
     
     public class PushNotificationSettings : ModelBase,
         ILoadableFrom<PushNotificationSettingsInternalDTO, PushNotificationSettings>,
-        ILoadableFrom<PushNotificationSettingsRequestInternalDTO, PushNotificationSettings>,
-        ILoadableFrom<PushNotificationSettingsResponseInternalDTO, PushNotificationSettings>,
-        ISavableTo<PushNotificationSettingsInternalDTO>, ISavableTo<PushNotificationSettingsRequestInternalDTO>
+        ILoadableFrom2<PushNotificationSettingsRequestInternalDTO, PushNotificationSettings>,
+        ILoadableFrom3<PushNotificationSettingsResponseInternalDTO, PushNotificationSettings>,
+        ISavableTo<PushNotificationSettingsInternalDTO>, ISavableTo2<PushNotificationSettingsRequestInternalDTO>
     {
         public bool? Disabled { get; set; }
 
@@ -25,7 +25,7 @@ namespace StreamChat.Core.LowLevelClient.Models
             return this;
         }
         
-        PushNotificationSettings ILoadableFrom<PushNotificationSettingsRequestInternalDTO, PushNotificationSettings>.
+        PushNotificationSettings ILoadableFrom2<PushNotificationSettingsRequestInternalDTO, PushNotificationSettings>.
             LoadFromDto(PushNotificationSettingsRequestInternalDTO dto)
         {
             Disabled = dto.Disabled;
@@ -35,7 +35,7 @@ namespace StreamChat.Core.LowLevelClient.Models
             return this;
         }
         
-        PushNotificationSettings ILoadableFrom<PushNotificationSettingsResponseInternalDTO, PushNotificationSettings>.
+        PushNotificationSettings ILoadableFrom3<PushNotificationSettingsResponseInternalDTO, PushNotificationSettings>.
             LoadFromDto(PushNotificationSettingsResponseInternalDTO dto)
         {
             Disabled = dto.Disabled;
@@ -53,7 +53,7 @@ namespace StreamChat.Core.LowLevelClient.Models
                 AdditionalProperties = AdditionalProperties,
             };
         
-        PushNotificationSettingsRequestInternalDTO ISavableTo<PushNotificationSettingsRequestInternalDTO>.SaveToDto()
+        PushNotificationSettingsRequestInternalDTO ISavableTo2<PushNotificationSettingsRequestInternalDTO>.SaveToDto()
             => new PushNotificationSettingsRequestInternalDTO
             {
                 Disabled = Disabled,

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/Reaction.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/Reaction.cs
@@ -9,7 +9,7 @@ namespace StreamChat.Core.LowLevelClient.Models
     /// Represents user reaction to a message
     /// </summary>
     public class Reaction : ResponseObjectBase, ILoadableFrom<ReactionInternalDTO, Reaction>, 
-        ILoadableFrom<ReactionResponseInternalDTO, Reaction>
+        ILoadableFrom2<ReactionResponseInternalDTO, Reaction>
     {
         /// <summary>
         /// Date/time of creation
@@ -57,7 +57,7 @@ namespace StreamChat.Core.LowLevelClient.Models
             return this;
         }
         
-        Reaction ILoadableFrom<ReactionResponseInternalDTO, Reaction>.LoadFromDto(ReactionResponseInternalDTO dto)
+        Reaction ILoadableFrom2<ReactionResponseInternalDTO, Reaction>.LoadFromDto(ReactionResponseInternalDTO dto)
         {
             AdditionalProperties = dto.AdditionalProperties;
             CreatedAt = dto.CreatedAt;

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/User.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Models/User.cs
@@ -7,8 +7,8 @@ namespace StreamChat.Core.LowLevelClient.Models
 {
     //StreamTODO: Check if this object is needed. Ideally we'd only have IStreamUser object representing a user and remove this one
     public class User : ModelBase, ILoadableFrom<UserObjectInternalDTO, User>,
-        ILoadableFrom<UserResponseInternalDTO, User>, ILoadableFrom<UserEventPayloadInternalDTO, User>,
-        ILoadableFrom<FullUserResponseInternalDTO, User>,
+        ILoadableFrom2<UserResponseInternalDTO, User>, ILoadableFrom3<UserEventPayloadInternalDTO, User>,
+        ILoadableFrom4<FullUserResponseInternalDTO, User>,
         ISavableTo<UserObjectInternalDTO>
     {
         /// <summary>
@@ -113,7 +113,7 @@ namespace StreamChat.Core.LowLevelClient.Models
             return this;
         }
 
-        User ILoadableFrom<UserResponseInternalDTO, User>.LoadFromDto(UserResponseInternalDTO dto)
+        User ILoadableFrom2<UserResponseInternalDTO, User>.LoadFromDto(UserResponseInternalDTO dto)
         {
             AdditionalProperties = dto.AdditionalProperties;
             BanExpires = dto.BanExpires;
@@ -141,7 +141,7 @@ namespace StreamChat.Core.LowLevelClient.Models
             return this;
         }
 
-        User ILoadableFrom<UserEventPayloadInternalDTO, User>.LoadFromDto(UserEventPayloadInternalDTO dto)
+        User ILoadableFrom3<UserEventPayloadInternalDTO, User>.LoadFromDto(UserEventPayloadInternalDTO dto)
         {
             AdditionalProperties = dto.AdditionalProperties;
             BanExpires = dto.BanExpires;
@@ -193,7 +193,7 @@ namespace StreamChat.Core.LowLevelClient.Models
                 Image = Image,
             };
 
-        User ILoadableFrom<FullUserResponseInternalDTO, User>.LoadFromDto(FullUserResponseInternalDTO dto)
+        User ILoadableFrom4<FullUserResponseInternalDTO, User>.LoadFromDto(FullUserResponseInternalDTO dto)
         {
             AdditionalProperties = dto.AdditionalProperties;
             BanExpires = dto.BanExpires;

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/ChannelMemberRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/ChannelMemberRequest.cs
@@ -5,7 +5,7 @@ using StreamChat.Core.InternalDTO.Requests;
 
 namespace StreamChat.Core.LowLevelClient.Requests
 {
-    public partial class ChannelMemberRequest : RequestObjectBase, ISavableTo<ChannelMemberRequestInternalDTO>, ISavableTo<ChannelMemberInternalDTO>
+    public partial class ChannelMemberRequest : RequestObjectBase, ISavableTo<ChannelMemberInternalDTO>, ISavableTo2<ChannelMemberRequestInternalDTO>
     {
         /// <summary>
         /// Expiration date of the ban
@@ -69,7 +69,7 @@ namespace StreamChat.Core.LowLevelClient.Requests
 
         public string UserId { get; set; }
 
-        ChannelMemberRequestInternalDTO ISavableTo<ChannelMemberRequestInternalDTO>.SaveToDto() =>
+        ChannelMemberRequestInternalDTO ISavableTo2<ChannelMemberRequestInternalDTO>.SaveToDto() =>
             new ChannelMemberRequestInternalDTO
             {
                 BanExpires = BanExpires,

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/ChannelRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/ChannelRequest.cs
@@ -54,7 +54,7 @@ namespace StreamChat.Core.LowLevelClient.Requests
                 CreatedBy = CreatedBy.TrySaveToDto<UserObjectRequestInternalDTO>(),
                 Disabled = Disabled,
                 Frozen = Frozen,
-                Members = Members.TrySaveToDtoCollection<ChannelMemberRequest, ChannelMemberRequestInternalDTO>(),
+                Members = Members.TrySaveToDtoCollection2<ChannelMemberRequest, ChannelMemberRequestInternalDTO>(),
                 OwnCapabilities = OwnCapabilities,
                 Team = Team,
                 TruncatedAt = TruncatedAt,

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/PushNotificationSettingsRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/PushNotificationSettingsRequest.cs
@@ -4,7 +4,7 @@ using StreamChat.Core.InternalDTO.Requests;
 
 namespace StreamChat.Core.LowLevelClient.Requests
 {
-    public class PushNotificationSettingsRequest : RequestObjectBase, ISavableTo<PushNotificationSettingsRequestInternalDTO>, ISavableTo<PushNotificationSettingsInternalDTO>
+    public class PushNotificationSettingsRequest : RequestObjectBase, ISavableTo<PushNotificationSettingsRequestInternalDTO>, ISavableTo2<PushNotificationSettingsInternalDTO>
     {
         public bool Disabled { get; set; }
 
@@ -18,7 +18,7 @@ namespace StreamChat.Core.LowLevelClient.Requests
                 AdditionalProperties = AdditionalProperties
             };
         
-        PushNotificationSettingsInternalDTO ISavableTo<PushNotificationSettingsInternalDTO>.SaveToDto() =>
+        PushNotificationSettingsInternalDTO ISavableTo2<PushNotificationSettingsInternalDTO>.SaveToDto() =>
             new PushNotificationSettingsInternalDTO
             {
                 Disabled = Disabled,

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/QueryUsersRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/QueryUsersRequest.cs
@@ -63,7 +63,7 @@ namespace StreamChat.Core.LowLevelClient.Requests
                 Limit = Limit,
                 Offset = Offset,
                 Presence = Presence,
-                Sort = Sort.TrySaveToDtoCollection<SortParamRequest, SortParamInternalDTO>(),
+                Sort = Sort.TrySaveToDtoCollection2<SortParamRequest, SortParamInternalDTO>(),
                 AdditionalProperties = AdditionalProperties,
             };
         }

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/SortParamRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/SortParamRequest.cs
@@ -3,7 +3,7 @@ using StreamChat.Core.InternalDTO.Requests;
 
 namespace StreamChat.Core.LowLevelClient.Requests
 {
-    public partial class SortParamRequest : RequestObjectBase, ISavableTo<SortParamRequestInternalDTO>, ISavableTo<SortParamInternalDTO>
+    public partial class SortParamRequest : RequestObjectBase, ISavableTo<SortParamRequestInternalDTO>, ISavableTo2<SortParamInternalDTO>
     {
         public int? Direction { get; set; }
 
@@ -17,7 +17,7 @@ namespace StreamChat.Core.LowLevelClient.Requests
                 AdditionalProperties = AdditionalProperties
             };
 
-        SortParamInternalDTO ISavableTo<SortParamInternalDTO>.SaveToDto() =>
+        SortParamInternalDTO ISavableTo2<SortParamInternalDTO>.SaveToDto() =>
             new SortParamInternalDTO
             {
                 Direction = Direction,

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/UserObjectRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Requests/UserObjectRequest.cs
@@ -10,7 +10,7 @@ namespace StreamChat.Core.LowLevelClient.Requests
     /// Represents chat user
     /// </summary>
     public class UserObjectRequest : RequestObjectBase, ISavableTo<UserObjectRequestInternalDTO>,
-        ISavableTo<UserRequestInternalDTO>, ISavableTo<UserObjectInternalDTO>
+        ISavableTo2<UserRequestInternalDTO>, ISavableTo3<UserObjectInternalDTO>
     {
         /// <summary>
         /// Expiration date of the ban
@@ -66,7 +66,7 @@ namespace StreamChat.Core.LowLevelClient.Requests
                 AdditionalProperties = AdditionalProperties
             };
 
-        UserRequestInternalDTO ISavableTo<UserRequestInternalDTO>.SaveToDto()
+        UserRequestInternalDTO ISavableTo2<UserRequestInternalDTO>.SaveToDto()
             => new UserRequestInternalDTO
             {
                 BanExpires = BanExpires,
@@ -81,7 +81,7 @@ namespace StreamChat.Core.LowLevelClient.Requests
                 AdditionalProperties = AdditionalProperties
             };
 
-        UserObjectInternalDTO ISavableTo<UserObjectInternalDTO>.SaveToDto()
+        UserObjectInternalDTO ISavableTo3<UserObjectInternalDTO>.SaveToDto()
             => new UserObjectInternalDTO
             {
                 BanExpires = BanExpires,

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Responses/PollVotesResponse.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Responses/PollVotesResponse.cs
@@ -18,7 +18,7 @@ namespace StreamChat.Core.LowLevelClient.Responses
 
         PollVotesResponse ILoadableFrom<PollVotesResponseInternalDTO, PollVotesResponse>.LoadFromDto(PollVotesResponseInternalDTO dto)
         {
-            Votes = Votes.TryLoadFromDtoCollection(dto.Votes);
+            Votes = Votes.TryLoadFromDtoCollection2(dto.Votes);
             Next = dto.Next;
             Prev = dto.Prev;
             AdditionalProperties = dto.AdditionalProperties;

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Responses/QueryPollsResponse.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Responses/QueryPollsResponse.cs
@@ -18,7 +18,7 @@ namespace StreamChat.Core.LowLevelClient.Responses
 
         QueryPollsResponse ILoadableFrom<QueryPollsResponseInternalDTO, QueryPollsResponse>.LoadFromDto(QueryPollsResponseInternalDTO dto)
         {
-            Polls = Polls.TryLoadFromDtoCollection(dto.Polls);
+            Polls = Polls.TryLoadFromDtoCollection2(dto.Polls);
             Next = dto.Next;
             Prev = dto.Prev;
             AdditionalProperties = dto.AdditionalProperties;

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Responses/UpdateChannelPartialResponse.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Responses/UpdateChannelPartialResponse.cs
@@ -19,7 +19,7 @@ namespace StreamChat.Core.LowLevelClient.Responses
         {
             Channel = Channel.TryLoadFromDto(dto.Channel);
             Duration = dto.Duration;
-            Members = Members.TryLoadFromDtoCollection(dto.Members);
+            Members = Members.TryLoadFromDtoCollection2(dto.Members);
             AdditionalProperties = dto.AdditionalProperties;
 
             return this;

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Responses/UpdateUsersResponse.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Responses/UpdateUsersResponse.cs
@@ -19,7 +19,7 @@ namespace StreamChat.Core.LowLevelClient.Responses
         UpdateUsersResponse ILoadableFrom<UpdateUsersResponseInternalDTO, UpdateUsersResponse>.LoadFromDto(UpdateUsersResponseInternalDTO dto)
         {
             Duration = dto.Duration;
-            Users = Users.TryLoadFromDtoDictionary(dto.Users);
+            Users = Users.TryLoadFromDtoDictionary4(dto.Users);
             AdditionalProperties = dto.AdditionalProperties;
 
             return this;

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/Responses/UsersResponse.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/Responses/UsersResponse.cs
@@ -20,7 +20,7 @@ namespace StreamChat.Core.LowLevelClient.Responses
         UsersResponse ILoadableFrom<QueryUsersResponseInternalDTO, UsersResponse>.LoadFromDto(QueryUsersResponseInternalDTO dto)
         {
             Duration = dto.Duration;
-            Users = Users.TryLoadFromDtoCollection(dto.Users);
+            Users = Users.TryLoadFromDtoCollection4(dto.Users);
             AdditionalProperties = dto.AdditionalProperties;
 
             return this;

--- a/Assets/Plugins/StreamChat/Core/Models/StreamPollOption.cs
+++ b/Assets/Plugins/StreamChat/Core/Models/StreamPollOption.cs
@@ -10,7 +10,7 @@ namespace StreamChat.Core.Models
     /// Represents an option in a poll
     /// </summary>
     public class StreamPollOption : IStateLoadableFrom<PollOptionInternalDTO, StreamPollOption>,
-        IStateLoadableFrom<PollOptionResponseDataInternalDTO, StreamPollOption>
+        IStateLoadableFrom2<PollOptionResponseDataInternalDTO, StreamPollOption>
     {
         /// <summary>
         /// Custom data associated with this option
@@ -42,7 +42,7 @@ namespace StreamChat.Core.Models
             return this;
         }
 
-        StreamPollOption IStateLoadableFrom<PollOptionResponseDataInternalDTO, StreamPollOption>.LoadFromDto(PollOptionResponseDataInternalDTO dto, ICache cache)
+        StreamPollOption IStateLoadableFrom2<PollOptionResponseDataInternalDTO, StreamPollOption>.LoadFromDto(PollOptionResponseDataInternalDTO dto, ICache cache)
         {
             Custom = dto.Custom;
             Id = dto.Id;

--- a/Assets/Plugins/StreamChat/Core/Models/StreamPollVote.cs
+++ b/Assets/Plugins/StreamChat/Core/Models/StreamPollVote.cs
@@ -12,7 +12,7 @@ namespace StreamChat.Core.Models
     /// Represents a vote cast on a poll
     /// </summary>
     public class StreamPollVote : IStateLoadableFrom<PollVoteInternalDTO, StreamPollVote>, 
-        IStateLoadableFrom<PollVoteResponseDataInternalDTO, StreamPollVote>
+        IStateLoadableFrom2<PollVoteResponseDataInternalDTO, StreamPollVote>
     {
         /// <summary>
         /// Text answer for the vote (if poll allows answers)
@@ -80,7 +80,7 @@ namespace StreamChat.Core.Models
             return this;
         }
 
-        StreamPollVote IStateLoadableFrom<PollVoteResponseDataInternalDTO, StreamPollVote>.LoadFromDto(PollVoteResponseDataInternalDTO dto, ICache cache)
+        StreamPollVote IStateLoadableFrom2<PollVoteResponseDataInternalDTO, StreamPollVote>.LoadFromDto(PollVoteResponseDataInternalDTO dto, ICache cache)
         {
             AnswerText = dto.AnswerText;
             CreatedAt = dto.CreatedAt;

--- a/Assets/Plugins/StreamChat/Core/Models/StreamPushNotificationSettings.cs
+++ b/Assets/Plugins/StreamChat/Core/Models/StreamPushNotificationSettings.cs
@@ -7,7 +7,7 @@ namespace StreamChat.Core.Models
 {
     public class StreamPushNotificationSettings :
         IStateLoadableFrom<PushNotificationSettingsInternalDTO, StreamPushNotificationSettings>,
-        IStateLoadableFrom<PushNotificationSettingsResponseInternalDTO, StreamPushNotificationSettings>
+        IStateLoadableFrom2<PushNotificationSettingsResponseInternalDTO, StreamPushNotificationSettings>
     {
         public bool Disabled { get; private set; }
 
@@ -24,7 +24,7 @@ namespace StreamChat.Core.Models
         }
 
         StreamPushNotificationSettings
-            IStateLoadableFrom<PushNotificationSettingsResponseInternalDTO, StreamPushNotificationSettings>.LoadFromDto(
+            IStateLoadableFrom2<PushNotificationSettingsResponseInternalDTO, StreamPushNotificationSettings>.LoadFromDto(
                 PushNotificationSettingsResponseInternalDTO dto, ICache cache)
         {
             Disabled = dto.Disabled.GetValueOrDefault();

--- a/Assets/Plugins/StreamChat/Core/Models/StreamReaction.cs
+++ b/Assets/Plugins/StreamChat/Core/Models/StreamReaction.cs
@@ -9,7 +9,7 @@ namespace StreamChat.Core.Models
     /// <summary>
     /// Represents user reaction to a message
     /// </summary>
-    public class StreamReaction : IStateLoadableFrom<ReactionInternalDTO, StreamReaction>, IStateLoadableFrom<ReactionResponseInternalDTO, StreamReaction>
+    public class StreamReaction : IStateLoadableFrom<ReactionInternalDTO, StreamReaction>, IStateLoadableFrom2<ReactionResponseInternalDTO, StreamReaction>
     {
         /// <summary>
         /// Date/time of creation
@@ -59,7 +59,7 @@ namespace StreamChat.Core.Models
             return this;
         }
         
-        StreamReaction IStateLoadableFrom<ReactionResponseInternalDTO, StreamReaction>.LoadFromDto(ReactionResponseInternalDTO dto, ICache cache)
+        StreamReaction IStateLoadableFrom2<ReactionResponseInternalDTO, StreamReaction>.LoadFromDto(ReactionResponseInternalDTO dto, ICache cache)
         {
             CreatedAt = dto.CreatedAt;
             MessageId = dto.MessageId;

--- a/Assets/Plugins/StreamChat/Core/Models/StreamRead.cs
+++ b/Assets/Plugins/StreamChat/Core/Models/StreamRead.cs
@@ -9,7 +9,7 @@ namespace StreamChat.Core.Models
 {
     //StreamTodo: this could contain the last read StreamMessage
     public class StreamRead : IStateLoadableFrom<ReadInternalDTO, StreamRead>,
-        IStateLoadableFrom<ReadStateResponseInternalDTO, StreamRead>
+        IStateLoadableFrom2<ReadStateResponseInternalDTO, StreamRead>
     {
         public DateTimeOffset LastRead { get; private set; }
 
@@ -27,7 +27,7 @@ namespace StreamChat.Core.Models
             return this;
         }
         
-        StreamRead IStateLoadableFrom<ReadStateResponseInternalDTO, StreamRead>.LoadFromDto(ReadStateResponseInternalDTO dto, ICache cache)
+        StreamRead IStateLoadableFrom2<ReadStateResponseInternalDTO, StreamRead>.LoadFromDto(ReadStateResponseInternalDTO dto, ICache cache)
         {
             //Is this always set? What if a user marks empty channel as read? 
             LastRead = dto.LastRead; //StreamTodo: GetValueOrThrow? 

--- a/Assets/Plugins/StreamChat/Core/Requests/StreamChannelMemberRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/Requests/StreamChannelMemberRequest.cs
@@ -5,7 +5,7 @@ using StreamChat.Core.LowLevelClient;
 
 namespace StreamChat.Core.Requests
 {
-    public sealed class StreamChannelMemberRequest : ISavableTo<ChannelMemberRequestInternalDTO>, ISavableTo<ChannelMemberInternalDTO>
+    public sealed class StreamChannelMemberRequest : ISavableTo<ChannelMemberInternalDTO>, ISavableTo2<ChannelMemberRequestInternalDTO>
     {
         /// <summary>
         /// Expiration date of the ban
@@ -32,7 +32,7 @@ namespace StreamChat.Core.Requests
         /// </summary>
         public bool? ShadowBanned { get; set; }
 
-        ChannelMemberRequestInternalDTO ISavableTo<ChannelMemberRequestInternalDTO>.SaveToDto()
+        ChannelMemberRequestInternalDTO ISavableTo2<ChannelMemberRequestInternalDTO>.SaveToDto()
             => new ChannelMemberRequestInternalDTO
             {
                 BanExpires = BanExpires,

--- a/Assets/Plugins/StreamChat/Core/Requests/StreamPollOptionRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/Requests/StreamPollOptionRequest.cs
@@ -8,7 +8,7 @@ namespace StreamChat.Core.Requests
     /// <summary>
     /// Request to create a poll option
     /// </summary>
-    public class StreamPollOptionRequest : ISavableTo<PollOptionRequestInternalDTO>, ISavableTo<PollOptionInputInternalDTO>
+    public class StreamPollOptionRequest : ISavableTo<PollOptionInputInternalDTO>, ISavableTo2<PollOptionRequestInternalDTO>
     {
         /// <summary>
         /// Custom data for the option
@@ -20,7 +20,7 @@ namespace StreamChat.Core.Requests
         /// </summary>
         public string Text { get; set; }
 
-        PollOptionRequestInternalDTO ISavableTo<PollOptionRequestInternalDTO>.SaveToDto()
+        PollOptionRequestInternalDTO ISavableTo2<PollOptionRequestInternalDTO>.SaveToDto()
         {
             return new PollOptionRequestInternalDTO
             {

--- a/Assets/Plugins/StreamChat/Core/Requests/StreamQueryBannedUsersRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/Requests/StreamQueryBannedUsersRequest.cs
@@ -63,7 +63,7 @@ namespace StreamChat.Core.Requests
                 FilterConditions = FilterConditions,
                 Limit = Limit,
                 Offset = Offset,
-                Sort = Sort.TrySaveToDtoCollection<StreamSortParam, SortParamRequestInternalDTO>(),
+                Sort = Sort.TrySaveToDtoCollection2<StreamSortParam, SortParamRequestInternalDTO>(),
             };
     }
 }

--- a/Assets/Plugins/StreamChat/Core/Requests/StreamSortParam.cs
+++ b/Assets/Plugins/StreamChat/Core/Requests/StreamSortParam.cs
@@ -4,7 +4,7 @@ using StreamChat.Core.LowLevelClient;
 
 namespace StreamChat.Core.Requests
 {
-    public sealed class StreamSortParam : ISavableTo<SortParamInternalDTO>,  ISavableTo<SortParamRequestInternalDTO>
+    public sealed class StreamSortParam : ISavableTo<SortParamInternalDTO>,  ISavableTo2<SortParamRequestInternalDTO>
     {
         public int? Direction { get; set; }
 
@@ -17,7 +17,7 @@ namespace StreamChat.Core.Requests
                 Field = Field,
             };
         
-        SortParamRequestInternalDTO ISavableTo<SortParamRequestInternalDTO>.SaveToDto() =>
+        SortParamRequestInternalDTO ISavableTo2<SortParamRequestInternalDTO>.SaveToDto() =>
             new SortParamRequestInternalDTO
             {
                 Direction = Direction,

--- a/Assets/Plugins/StreamChat/Core/Requests/StreamUserUpsertRequest.cs
+++ b/Assets/Plugins/StreamChat/Core/Requests/StreamUserUpsertRequest.cs
@@ -7,7 +7,7 @@ using StreamChat.Core.StatefulModels;
 
 namespace StreamChat.Core.Requests
 {
-    public sealed class StreamUserUpsertRequest : ISavableTo<UserObjectRequestInternalDTO>, ISavableTo<UserRequestInternalDTO>
+    public sealed class StreamUserUpsertRequest : ISavableTo<UserRequestInternalDTO>, ISavableTo2<UserObjectRequestInternalDTO>
     {
         /// <summary>
         /// Expiration date of the ban
@@ -56,7 +56,7 @@ namespace StreamChat.Core.Requests
         /// </summary>
         public StreamCustomDataRequest CustomData { get; set; }
 
-        UserObjectRequestInternalDTO ISavableTo<UserObjectRequestInternalDTO>.SaveToDto()
+        UserObjectRequestInternalDTO ISavableTo2<UserObjectRequestInternalDTO>.SaveToDto()
             => new UserObjectRequestInternalDTO
             {
                 BanExpires = BanExpires,

--- a/Assets/Plugins/StreamChat/Core/State/Caches/Cache.cs
+++ b/Assets/Plugins/StreamChat/Core/State/Caches/Cache.cs
@@ -20,15 +20,15 @@ namespace StreamChat.Core.State.Caches
             Polls = new CacheRepository<StreamPoll>(trackedObjectsFactory.CreateStreamPoll, cache: this);
 
             Channels.RegisterDtoIdMapping<StreamChannel, ChannelStateResponseInternalDTO>(dto => dto.Channel.Cid);
-            Channels.RegisterDtoIdMapping<StreamChannel, ChannelResponseInternalDTO>(dto => dto.Cid);
-            Channels.RegisterDtoIdMapping<StreamChannel, ChannelStateResponseFieldsInternalDTO>(dto => dto.Channel.Cid);
-            Channels.RegisterDtoIdMapping<StreamChannel, UpdateChannelResponseInternalDTO>(dto => dto.Channel.Cid);
+            Channels.RegisterDtoIdMapping2<StreamChannel, ChannelResponseInternalDTO>(dto => dto.Cid);
+            Channels.RegisterDtoIdMapping3<StreamChannel, ChannelStateResponseFieldsInternalDTO>(dto => dto.Channel.Cid);
+            Channels.RegisterDtoIdMapping4<StreamChannel, UpdateChannelResponseInternalDTO>(dto => dto.Channel.Cid);
 
             Users.RegisterDtoIdMapping<StreamUser, UserObjectInternalDTO>(dto => dto.Id);
-            Users.RegisterDtoIdMapping<StreamUser, UserResponseInternalDTO>(dto => dto.Id);
-            Users.RegisterDtoIdMapping<StreamUser, OwnUserInternalDTO>(dto => dto.Id);
-            Users.RegisterDtoIdMapping<StreamUser, FullUserResponseInternalDTO>(dto => dto.Id);
-            Users.RegisterDtoIdMapping<StreamUser, UserEventPayloadInternalDTO>(dto => dto.Id);
+            Users.RegisterDtoIdMapping2<StreamUser, UserResponseInternalDTO>(dto => dto.Id);
+            Users.RegisterDtoIdMapping3<StreamUser, OwnUserInternalDTO>(dto => dto.Id);
+            Users.RegisterDtoIdMapping4<StreamUser, FullUserResponseInternalDTO>(dto => dto.Id);
+            Users.RegisterDtoIdMapping5<StreamUser, UserEventPayloadInternalDTO>(dto => dto.Id);
 
             LocalUser.RegisterDtoIdMapping<StreamLocalUserData, OwnUserInternalDTO>(dto => dto.Id);
 
@@ -44,7 +44,7 @@ namespace StreamChat.Core.State.Caches
             });
 
             Messages.RegisterDtoIdMapping<StreamMessage, MessageInternalDTO>(dto => dto.Id);
-            Messages.RegisterDtoIdMapping<StreamMessage, MessageResponseInternalDTO>(dto => dto.Id);
+            Messages.RegisterDtoIdMapping2<StreamMessage, MessageResponseInternalDTO>(dto => dto.Id);
 
             Polls.RegisterDtoIdMapping<StreamPoll, PollResponseDataInternalDTO>(dto => dto.Id);
         }

--- a/Assets/Plugins/StreamChat/Core/State/Caches/CacheRepository.cs
+++ b/Assets/Plugins/StreamChat/Core/State/Caches/CacheRepository.cs
@@ -35,37 +35,74 @@ namespace StreamChat.Core.State.Caches
             where TType : class, TStatefulModel, IStreamStatefulModel, IUpdateableFrom<TDto, TType>
             where TDto : class
         {
-            var key = typeof(TDto);
+            RegisterDtoIdMappingInternal(idGetter);
+        }
 
-            if (_dtoIdGetters.ContainsKey(key))
-            {
-                throw new InvalidOperationException("Key is already registered: " + key);
-            }
+        public void RegisterDtoIdMapping2<TType, TDto>(Func<TDto, string> idGetter)
+            where TType : class, TStatefulModel, IStreamStatefulModel, IUpdateableFrom2<TDto, TType>
+            where TDto : class
+        {
+            RegisterDtoIdMappingInternal(idGetter);
+        }
 
-            string Wrapper(object obj) => idGetter(obj as TDto);
+        public void RegisterDtoIdMapping3<TType, TDto>(Func<TDto, string> idGetter)
+            where TType : class, TStatefulModel, IStreamStatefulModel, IUpdateableFrom3<TDto, TType>
+            where TDto : class
+        {
+            RegisterDtoIdMappingInternal(idGetter);
+        }
 
-            _dtoIdGetters.Add(key, Wrapper);
+        public void RegisterDtoIdMapping4<TType, TDto>(Func<TDto, string> idGetter)
+            where TType : class, TStatefulModel, IStreamStatefulModel, IUpdateableFrom4<TDto, TType>
+            where TDto : class
+        {
+            RegisterDtoIdMappingInternal(idGetter);
+        }
+
+        public void RegisterDtoIdMapping5<TType, TDto>(Func<TDto, string> idGetter)
+            where TType : class, TStatefulModel, IStreamStatefulModel, IUpdateableFrom5<TDto, TType>
+            where TDto : class
+        {
+            RegisterDtoIdMappingInternal(idGetter);
         }
 
         public TType CreateOrUpdate<TType, TDto>(TDto dto, out bool wasCreated)
             where TType : class, TStatefulModel, IStreamStatefulModel, IUpdateableFrom<TDto, TType>
         {
-            wasCreated = false;
-            var trackingId = GetDtoMappingId(dto);
-            if (!TryGet(trackingId, out var trackedObject))
-            {
-                trackedObject = _constructor(trackingId);
-                wasCreated = true;
-            }
-
-            var typedStatefulModel = trackedObject as TType;
-            if (typedStatefulModel == null)
-            {
-                throw new InvalidOperationException($"Failed to cast {typeof(TStatefulModel)} to {typeof(TType)}");
-            }
-
+            var typedStatefulModel = GetOrCreateStatefulModel<TType, TDto>(dto, out wasCreated);
             typedStatefulModel.UpdateFromDto(dto, _cache);
+            return typedStatefulModel;
+        }
 
+        public TType CreateOrUpdate2<TType, TDto>(TDto dto, out bool wasCreated)
+            where TType : class, TStatefulModel, IStreamStatefulModel, IUpdateableFrom2<TDto, TType>
+        {
+            var typedStatefulModel = GetOrCreateStatefulModel<TType, TDto>(dto, out wasCreated);
+            typedStatefulModel.UpdateFromDto(dto, _cache);
+            return typedStatefulModel;
+        }
+
+        public TType CreateOrUpdate3<TType, TDto>(TDto dto, out bool wasCreated)
+            where TType : class, TStatefulModel, IStreamStatefulModel, IUpdateableFrom3<TDto, TType>
+        {
+            var typedStatefulModel = GetOrCreateStatefulModel<TType, TDto>(dto, out wasCreated);
+            typedStatefulModel.UpdateFromDto(dto, _cache);
+            return typedStatefulModel;
+        }
+
+        public TType CreateOrUpdate4<TType, TDto>(TDto dto, out bool wasCreated)
+            where TType : class, TStatefulModel, IStreamStatefulModel, IUpdateableFrom4<TDto, TType>
+        {
+            var typedStatefulModel = GetOrCreateStatefulModel<TType, TDto>(dto, out wasCreated);
+            typedStatefulModel.UpdateFromDto(dto, _cache);
+            return typedStatefulModel;
+        }
+
+        public TType CreateOrUpdate5<TType, TDto>(TDto dto, out bool wasCreated)
+            where TType : class, TStatefulModel, IStreamStatefulModel, IUpdateableFrom5<TDto, TType>
+        {
+            var typedStatefulModel = GetOrCreateStatefulModel<TType, TDto>(dto, out wasCreated);
+            typedStatefulModel.UpdateFromDto(dto, _cache);
             return typedStatefulModel;
         }
 
@@ -108,6 +145,40 @@ namespace StreamChat.Core.State.Caches
         {
             _constructor = constructor ?? throw new ArgumentNullException(nameof(constructor));
             _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        }
+
+        private void RegisterDtoIdMappingInternal<TDto>(Func<TDto, string> idGetter) where TDto : class
+        {
+            var key = typeof(TDto);
+
+            if (_dtoIdGetters.ContainsKey(key))
+            {
+                throw new InvalidOperationException("Key is already registered: " + key);
+            }
+
+            string Wrapper(object obj) => idGetter(obj as TDto);
+
+            _dtoIdGetters.Add(key, Wrapper);
+        }
+
+        private TType GetOrCreateStatefulModel<TType, TDto>(TDto dto, out bool wasCreated)
+            where TType : class, TStatefulModel, IStreamStatefulModel
+        {
+            wasCreated = false;
+            var trackingId = GetDtoMappingId(dto);
+            if (!TryGet(trackingId, out var trackedObject))
+            {
+                trackedObject = _constructor(trackingId);
+                wasCreated = true;
+            }
+
+            var typedStatefulModel = trackedObject as TType;
+            if (typedStatefulModel == null)
+            {
+                throw new InvalidOperationException($"Failed to cast {typeof(TStatefulModel)} to {typeof(TType)}");
+            }
+
+            return typedStatefulModel;
         }
 
         private readonly List<TStatefulModel> _statefulModels = new List<TStatefulModel>();

--- a/Assets/Plugins/StreamChat/Core/State/Caches/ICacheExt.cs
+++ b/Assets/Plugins/StreamChat/Core/State/Caches/ICacheExt.cs
@@ -10,7 +10,7 @@ namespace StreamChat.Core.State.Caches
             => dto == null ? null : cache.Messages.CreateOrUpdate<StreamMessage, MessageInternalDTO>(dto, out _);
         
         public static StreamMessage TryCreateOrUpdate(this ICache cache, MessageResponseInternalDTO dto)
-            => dto == null ? null : cache.Messages.CreateOrUpdate<StreamMessage, MessageResponseInternalDTO>(dto, out _);
+            => dto == null ? null : cache.Messages.CreateOrUpdate2<StreamMessage, MessageResponseInternalDTO>(dto, out _);
 
         public static StreamMessage TryCreateOrUpdate(this ICache cache, MessageInternalDTO dto, out bool wasCreated)
         {
@@ -23,20 +23,20 @@ namespace StreamChat.Core.State.Caches
         public static StreamChannel TryCreateOrUpdate(this ICache cache, ChannelResponseInternalDTO dto)
             => dto == null
                 ? null
-                : cache.Channels.CreateOrUpdate<StreamChannel, ChannelResponseInternalDTO>(dto, out _);
+                : cache.Channels.CreateOrUpdate2<StreamChannel, ChannelResponseInternalDTO>(dto, out _);
         
         public static StreamChannel TryCreateOrUpdate(this ICache cache, ChannelResponseInternalDTO dto, out bool wasCreated)
         {
             wasCreated = false;
             return dto == null
                 ? null
-                : cache.Channels.CreateOrUpdate<StreamChannel, ChannelResponseInternalDTO>(dto, out wasCreated);
+                : cache.Channels.CreateOrUpdate2<StreamChannel, ChannelResponseInternalDTO>(dto, out wasCreated);
         }
 
         public static StreamChannel TryCreateOrUpdate(this ICache cache, ChannelStateResponseFieldsInternalDTO dto)
             => dto == null
                 ? null
-                : cache.Channels.CreateOrUpdate<StreamChannel, ChannelStateResponseFieldsInternalDTO>(dto, out _);
+                : cache.Channels.CreateOrUpdate3<StreamChannel, ChannelStateResponseFieldsInternalDTO>(dto, out _);
 
         public static StreamChannel TryCreateOrUpdate(this ICache cache, ChannelStateResponseInternalDTO dto)
             => dto == null
@@ -46,7 +46,7 @@ namespace StreamChat.Core.State.Caches
         public static StreamChannel TryCreateOrUpdate(this ICache cache, UpdateChannelResponseInternalDTO dto)
             => dto == null
                 ? null
-                : cache.Channels.CreateOrUpdate<StreamChannel, UpdateChannelResponseInternalDTO>(dto, out _);
+                : cache.Channels.CreateOrUpdate4<StreamChannel, UpdateChannelResponseInternalDTO>(dto, out _);
 
         public static StreamChannelMember TryCreateOrUpdate(this ICache cache, ChannelMemberInternalDTO dto)
             => dto == null
@@ -54,7 +54,7 @@ namespace StreamChat.Core.State.Caches
                 : cache.ChannelMembers.CreateOrUpdate<StreamChannelMember, ChannelMemberInternalDTO>(dto, out _);
 
         public static StreamUser TryCreateOrUpdate(this ICache cache, UserResponseInternalDTO dto)
-            => dto == null ? null : cache.Users.CreateOrUpdate<StreamUser, UserResponseInternalDTO>(dto, out _);
+            => dto == null ? null : cache.Users.CreateOrUpdate2<StreamUser, UserResponseInternalDTO>(dto, out _);
         
         public static StreamUser TryCreateOrUpdate(this ICache cache, UserObjectInternalDTO dto)
             => dto == null ? null : cache.Users.CreateOrUpdate<StreamUser, UserObjectInternalDTO>(dto, out _);
@@ -72,10 +72,10 @@ namespace StreamChat.Core.State.Caches
             => dto == null ? null : cache.LocalUser.CreateOrUpdate<StreamLocalUserData, OwnUserInternalDTO>(dto, out _);
         
         public static StreamUser TryCreateOrUpdate(this ICache cache, FullUserResponseInternalDTO dto)
-            => dto == null ? null : cache.Users.CreateOrUpdate<StreamUser, FullUserResponseInternalDTO>(dto, out _);
+            => dto == null ? null : cache.Users.CreateOrUpdate4<StreamUser, FullUserResponseInternalDTO>(dto, out _);
         
         public static StreamUser TryCreateOrUpdate(this ICache cache, UserEventPayloadInternalDTO dto)
-            => dto == null ? null : cache.Users.CreateOrUpdate<StreamUser, UserEventPayloadInternalDTO>(dto, out _);
+            => dto == null ? null : cache.Users.CreateOrUpdate5<StreamUser, UserEventPayloadInternalDTO>(dto, out _);
         
         public static StreamPoll TryCreateOrUpdate(this ICache cache, PollResponseDataInternalDTO dto)
             => dto == null ? null : cache.Polls.CreateOrUpdate<StreamPoll, PollResponseDataInternalDTO>(dto, out _);

--- a/Assets/Plugins/StreamChat/Core/State/Caches/ICacheRepository.cs
+++ b/Assets/Plugins/StreamChat/Core/State/Caches/ICacheRepository.cs
@@ -20,8 +20,36 @@ namespace StreamChat.Core.State.Caches
             where TType : class, TTrackedObject, IStreamStatefulModel, IUpdateableFrom<TDto, TType>
             where TDto : class;
 
+        void RegisterDtoIdMapping2<TType, TDto>(Func<TDto, string> idGetter)
+            where TType : class, TTrackedObject, IStreamStatefulModel, IUpdateableFrom2<TDto, TType>
+            where TDto : class;
+
+        void RegisterDtoIdMapping3<TType, TDto>(Func<TDto, string> idGetter)
+            where TType : class, TTrackedObject, IStreamStatefulModel, IUpdateableFrom3<TDto, TType>
+            where TDto : class;
+
+        void RegisterDtoIdMapping4<TType, TDto>(Func<TDto, string> idGetter)
+            where TType : class, TTrackedObject, IStreamStatefulModel, IUpdateableFrom4<TDto, TType>
+            where TDto : class;
+
+        void RegisterDtoIdMapping5<TType, TDto>(Func<TDto, string> idGetter)
+            where TType : class, TTrackedObject, IStreamStatefulModel, IUpdateableFrom5<TDto, TType>
+            where TDto : class;
+
         TType CreateOrUpdate<TType, TDto>(TDto dto, out bool wasCreated)
             where TType : class, TTrackedObject, IStreamStatefulModel, IUpdateableFrom<TDto, TType>;
+
+        TType CreateOrUpdate2<TType, TDto>(TDto dto, out bool wasCreated)
+            where TType : class, TTrackedObject, IStreamStatefulModel, IUpdateableFrom2<TDto, TType>;
+
+        TType CreateOrUpdate3<TType, TDto>(TDto dto, out bool wasCreated)
+            where TType : class, TTrackedObject, IStreamStatefulModel, IUpdateableFrom3<TDto, TType>;
+
+        TType CreateOrUpdate4<TType, TDto>(TDto dto, out bool wasCreated)
+            where TType : class, TTrackedObject, IStreamStatefulModel, IUpdateableFrom4<TDto, TType>;
+
+        TType CreateOrUpdate5<TType, TDto>(TDto dto, out bool wasCreated)
+            where TType : class, TTrackedObject, IStreamStatefulModel, IUpdateableFrom5<TDto, TType>;
 
         void Remove(TTrackedObject trackedObject);
     }

--- a/Assets/Plugins/StreamChat/Core/State/IRepositoryExt.cs
+++ b/Assets/Plugins/StreamChat/Core/State/IRepositoryExt.cs
@@ -80,6 +80,73 @@ namespace StreamChat.Core.State
             }
         }
 
+        public static void TryReplaceTrackedObjects2<TTracked, TDto>(this IList<TTracked> target, IEnumerable<TDto> dtos,
+            ICacheRepository<TTracked> repository)
+            where TTracked : class, IStreamStatefulModel, IUpdateableFrom2<TDto, TTracked>
+        {
+            if (target == null)
+            {
+                throw new ArgumentException(nameof(target));
+            }
+
+            if (dtos == null)
+            {
+                return;
+            }
+
+            target.Clear();
+
+            foreach (var dto in dtos)
+            {
+                var trackedItem = repository.CreateOrUpdate2<TTracked, TDto>(dto, out _);
+                try
+                {
+                    target.Add(trackedItem);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        public static void TryAppendUniqueTrackedObjects2<TTracked, TDto>(this IList<TTracked> target,
+            IEnumerable<TDto> dtos, ICacheRepository<TTracked> repository)
+            where TTracked : class, IStreamStatefulModel, IUpdateableFrom2<TDto, TTracked>
+        {
+            if (target == null)
+            {
+                throw new ArgumentException(nameof(target));
+            }
+
+            if (dtos == null)
+            {
+                return;
+            }
+
+            _uniqueElements.Clear();
+
+            foreach (var t in target)
+            {
+                _uniqueElements.Add(t);
+            }
+
+            foreach (var dto in dtos)
+            {
+                var trackedItem = repository.CreateOrUpdate2<TTracked, TDto>(dto, out _);
+
+                if (_uniqueElements.Add(trackedItem))
+                {
+                    try
+                    {
+                        target.Add(trackedItem);
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+        }
+
         private static readonly HashSet<object> _uniqueElements = new HashSet<object>();
     }
 }

--- a/Assets/Plugins/StreamChat/Core/State/IStateLoadableFrom.cs
+++ b/Assets/Plugins/StreamChat/Core/State/IStateLoadableFrom.cs
@@ -17,6 +17,12 @@ namespace StreamChat.Core.State
         TDomain LoadFromDto(TDto dto, ICache cache);
     }
 
+    internal interface IStateLoadableFrom2<in TDto, out TDomain>
+        where TDomain : IStateLoadableFrom2<TDto, TDomain>
+    {
+        TDomain LoadFromDto(TDto dto, ICache cache);
+    }
+
     /// <summary>
     /// Extensions for <see cref="ILoadableFrom{TDto,TDomain}"/>
     /// </summary>
@@ -32,9 +38,36 @@ namespace StreamChat.Core.State
 
             return new TDomain().LoadFromDto(dto, cache);
         }
-        
+
+        public static TDomain TryLoadFromDto<TDto, TDomain>(this IStateLoadableFrom2<TDto, TDomain> loadable, TDto dto, ICache cache)
+            where TDomain : class, IStateLoadableFrom2<TDto, TDomain>, new()
+        {
+            if (dto == null)
+            {
+                return null;
+            }
+
+            return new TDomain().LoadFromDto(dto, cache);
+        }
+
         public static TDomain LoadFromDto<TDto, TDomain>(this IStateLoadableFrom<TDto, TDomain> loadable, TDto dto, ICache cache)
             where TDomain : class, IStateLoadableFrom<TDto, TDomain>, new()
+        {
+            if (dto == null)
+            {
+                return null;
+            }
+
+            if (loadable == null)
+            {
+                throw new ArgumentException(nameof(loadable));
+            }
+
+            return loadable.LoadFromDto(dto, cache);
+        }
+
+        public static TDomain LoadFromDto<TDto, TDomain>(this IStateLoadableFrom2<TDto, TDomain> loadable, TDto dto, ICache cache)
+            where TDomain : class, IStateLoadableFrom2<TDto, TDomain>, new()
         {
             if (dto == null)
             {
@@ -68,12 +101,59 @@ namespace StreamChat.Core.State
             return items;
         }
 
+        [Pure]
+        public static List<TSource> TryLoadFromDtoCollection2<TDto, TSource>(this List<TSource> _, List<TDto> dtos, ICache cache)
+            where TSource : IStateLoadableFrom2<TDto, TSource>, new()
+        {
+            if (dtos == null)
+            {
+                return null;
+            }
+
+            var items = new List<TSource>(dtos.Count);
+
+            foreach (var dto in dtos)
+            {
+                items.Add(new TSource().LoadFromDto(dto, cache));
+            }
+
+            return items;
+        }
 
         /// <summary>
         /// Regular = non tracked objects
         /// </summary>
         public static void TryReplaceRegularObjectsFromDto<TDto, TSource>(this List<TSource> target, List<TDto> dtos, ICache cache)
             where TSource : IStateLoadableFrom<TDto, TSource>, new()
+        {
+            if (typeof(TSource) is IStreamStatefulModel)
+            {
+                throw new InvalidOperationException("This method should not be used for tracked objects");
+            }
+
+            if (dtos == null)
+            {
+                return;
+            }
+
+            if (target == null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
+
+            target.Clear();
+
+            foreach (var dto in dtos)
+            {
+                target.Add(new TSource().LoadFromDto(dto, cache));
+            }
+        }
+
+        /// <summary>
+        /// Regular = non tracked objects
+        /// </summary>
+        public static void TryReplaceRegularObjectsFromDto2<TDto, TSource>(this List<TSource> target, List<TDto> dtos, ICache cache)
+            where TSource : IStateLoadableFrom2<TDto, TSource>, new()
         {
             if (typeof(TSource) is IStreamStatefulModel)
             {

--- a/Assets/Plugins/StreamChat/Core/State/IUpdateableFrom.cs
+++ b/Assets/Plugins/StreamChat/Core/State/IUpdateableFrom.cs
@@ -7,4 +7,28 @@ namespace StreamChat.Core.State
     {
         void UpdateFromDto(TDto dto, ICache cache);
     }
+
+    internal interface IUpdateableFrom2<in TDto, out TTrackedObject>
+        where TTrackedObject : IStreamStatefulModel, IUpdateableFrom2<TDto, TTrackedObject>
+    {
+        void UpdateFromDto(TDto dto, ICache cache);
+    }
+
+    internal interface IUpdateableFrom3<in TDto, out TTrackedObject>
+        where TTrackedObject : IStreamStatefulModel, IUpdateableFrom3<TDto, TTrackedObject>
+    {
+        void UpdateFromDto(TDto dto, ICache cache);
+    }
+
+    internal interface IUpdateableFrom4<in TDto, out TTrackedObject>
+        where TTrackedObject : IStreamStatefulModel, IUpdateableFrom4<TDto, TTrackedObject>
+    {
+        void UpdateFromDto(TDto dto, ICache cache);
+    }
+
+    internal interface IUpdateableFrom5<in TDto, out TTrackedObject>
+        where TTrackedObject : IStreamStatefulModel, IUpdateableFrom5<TDto, TTrackedObject>
+    {
+        void UpdateFromDto(TDto dto, ICache cache);
+    }
 }

--- a/Assets/Plugins/StreamChat/Core/State/UpdateableFromExt.cs
+++ b/Assets/Plugins/StreamChat/Core/State/UpdateableFromExt.cs
@@ -9,5 +9,29 @@ namespace StreamChat.Core.State
         {
             updateable?.UpdateFromDto(dto, cache);
         }
+
+        public static void TryUpdateFromDto<TDto, TTrackedObject>(this IUpdateableFrom2<TDto, TTrackedObject> updateable, TDto dto, ICache cache)
+            where TTrackedObject : IStreamStatefulModel, IUpdateableFrom2<TDto, TTrackedObject>
+        {
+            updateable?.UpdateFromDto(dto, cache);
+        }
+
+        public static void TryUpdateFromDto<TDto, TTrackedObject>(this IUpdateableFrom3<TDto, TTrackedObject> updateable, TDto dto, ICache cache)
+            where TTrackedObject : IStreamStatefulModel, IUpdateableFrom3<TDto, TTrackedObject>
+        {
+            updateable?.UpdateFromDto(dto, cache);
+        }
+
+        public static void TryUpdateFromDto<TDto, TTrackedObject>(this IUpdateableFrom4<TDto, TTrackedObject> updateable, TDto dto, ICache cache)
+            where TTrackedObject : IStreamStatefulModel, IUpdateableFrom4<TDto, TTrackedObject>
+        {
+            updateable?.UpdateFromDto(dto, cache);
+        }
+
+        public static void TryUpdateFromDto<TDto, TTrackedObject>(this IUpdateableFrom5<TDto, TTrackedObject> updateable, TDto dto, ICache cache)
+            where TTrackedObject : IStreamStatefulModel, IUpdateableFrom5<TDto, TTrackedObject>
+        {
+            updateable?.UpdateFromDto(dto, cache);
+        }
     }
 }

--- a/Assets/Plugins/StreamChat/Core/StatefulModels/StreamChannel.cs
+++ b/Assets/Plugins/StreamChat/Core/StatefulModels/StreamChannel.cs
@@ -37,9 +37,9 @@ namespace StreamChat.Core.StatefulModels
 
     internal sealed class StreamChannel : StreamStatefulModelBase<StreamChannel>,
         IUpdateableFrom<ChannelStateResponseInternalDTO, StreamChannel>,
-        IUpdateableFrom<ChannelResponseInternalDTO, StreamChannel>,
-        IUpdateableFrom<ChannelStateResponseFieldsInternalDTO, StreamChannel>,
-        IUpdateableFrom<UpdateChannelResponseInternalDTO, StreamChannel>,
+        IUpdateableFrom2<ChannelResponseInternalDTO, StreamChannel>,
+        IUpdateableFrom3<ChannelStateResponseFieldsInternalDTO, StreamChannel>,
+        IUpdateableFrom4<UpdateChannelResponseInternalDTO, StreamChannel>,
         IStreamChannel
     {
         public event StreamChannelMessageHandler MessageReceived;
@@ -631,12 +631,12 @@ namespace StreamChat.Core.StatefulModels
             //This is needed because Channel.Members can be null while this is filled
             _members.TryAppendUniqueTrackedObjects(dto.Members, cache.ChannelMembers);
             Membership = cache.TryCreateOrUpdate(dto.Membership);
-            _messages.TryAppendUniqueTrackedObjects(dto.Messages, cache.Messages);
+            _messages.TryAppendUniqueTrackedObjects2(dto.Messages, cache.Messages);
             _pendingMessages.TryReplaceRegularObjectsFromDto(dto.PendingMessages, cache);
-            _pinnedMessages.TryReplaceTrackedObjects(dto.PinnedMessages, cache.Messages);
-            _read.TryReplaceRegularObjectsFromDto(dto.Read, cache);
+            _pinnedMessages.TryReplaceTrackedObjects2(dto.PinnedMessages, cache.Messages);
+            _read.TryReplaceRegularObjectsFromDto2(dto.Read, cache);
             WatcherCount = GetOrDefault(dto.WatcherCount, WatcherCount);
-            _watchers.TryAppendUniqueTrackedObjects(dto.Watchers, cache.Users);
+            _watchers.TryAppendUniqueTrackedObjects2(dto.Watchers, cache.Users);
 
             #endregion
 
@@ -645,7 +645,7 @@ namespace StreamChat.Core.StatefulModels
             //StreamTodo should every UpdateFromDto trigger Updated event?
         }
 
-        void IUpdateableFrom<ChannelStateResponseFieldsInternalDTO, StreamChannel>.UpdateFromDto(
+        void IUpdateableFrom3<ChannelStateResponseFieldsInternalDTO, StreamChannel>.UpdateFromDto(
             ChannelStateResponseFieldsInternalDTO dto, ICache cache)
         {
             UpdateChannelFieldsFromDto(dto.Channel, cache);
@@ -656,23 +656,23 @@ namespace StreamChat.Core.StatefulModels
             //HideMessagesBefore = dto.HideMessagesBefore; Updated from Channel
             _members.TryReplaceTrackedObjects(dto.Members, cache.ChannelMembers);
             Membership = cache.TryCreateOrUpdate(dto.Membership);
-            _messages.TryAppendUniqueTrackedObjects(dto.Messages, cache.Messages);
+            _messages.TryAppendUniqueTrackedObjects2(dto.Messages, cache.Messages);
             _pendingMessages.TryReplaceRegularObjectsFromDto(dto.PendingMessages, cache);
-            _pinnedMessages.TryReplaceTrackedObjects(dto.PinnedMessages, cache.Messages);
-            _read.TryReplaceRegularObjectsFromDto(dto.Read, cache);
+            _pinnedMessages.TryReplaceTrackedObjects2(dto.PinnedMessages, cache.Messages);
+            _read.TryReplaceRegularObjectsFromDto2(dto.Read, cache);
             WatcherCount = GetOrDefault(dto.WatcherCount, WatcherCount);
-            _watchers.TryAppendUniqueTrackedObjects(dto.Watchers, cache.Users);
+            _watchers.TryAppendUniqueTrackedObjects2(dto.Watchers, cache.Users);
 
             SortMessagesByCreatedAt();
 
             #endregion
         }
 
-        void IUpdateableFrom<ChannelResponseInternalDTO, StreamChannel>.UpdateFromDto(ChannelResponseInternalDTO dto,
+        void IUpdateableFrom2<ChannelResponseInternalDTO, StreamChannel>.UpdateFromDto(ChannelResponseInternalDTO dto,
             ICache cache)
             => UpdateChannelFieldsFromDto(dto, cache);
 
-        void IUpdateableFrom<UpdateChannelResponseInternalDTO, StreamChannel>.UpdateFromDto(
+        void IUpdateableFrom4<UpdateChannelResponseInternalDTO, StreamChannel>.UpdateFromDto(
             UpdateChannelResponseInternalDTO dto, ICache cache)
         {
             UpdateChannelFieldsFromDto(dto.Channel, cache);

--- a/Assets/Plugins/StreamChat/Core/StatefulModels/StreamLocalUserData.cs
+++ b/Assets/Plugins/StreamChat/Core/StatefulModels/StreamLocalUserData.cs
@@ -9,7 +9,7 @@ using StreamChat.Core.Models;
 namespace StreamChat.Core.StatefulModels
 {
     internal sealed class StreamLocalUserData : StreamStatefulModelBase<StreamLocalUserData>,
-        IUpdateableFrom<OwnUserInternalDTO, StreamLocalUserData>, IUpdateableFrom<WrappedUnreadCountsResponseInternalDTO, StreamLocalUserData>, IStreamLocalUserData
+        IUpdateableFrom<OwnUserInternalDTO, StreamLocalUserData>, IUpdateableFrom2<WrappedUnreadCountsResponseInternalDTO, StreamLocalUserData>, IStreamLocalUserData
     {
         #region OwnUser
         
@@ -46,7 +46,7 @@ namespace StreamChat.Core.StatefulModels
 
             #endregion
 
-            User = cache.Users.CreateOrUpdate<StreamUser, OwnUserInternalDTO>(dto, out _);
+            User = cache.Users.CreateOrUpdate3<StreamUser, OwnUserInternalDTO>(dto, out _);
 
             LoadAdditionalProperties(dto.AdditionalProperties);
             
@@ -55,7 +55,7 @@ namespace StreamChat.Core.StatefulModels
 #endif
         }
         
-        void IUpdateableFrom<WrappedUnreadCountsResponseInternalDTO, StreamLocalUserData>.UpdateFromDto(WrappedUnreadCountsResponseInternalDTO dto,
+        void IUpdateableFrom2<WrappedUnreadCountsResponseInternalDTO, StreamLocalUserData>.UpdateFromDto(WrappedUnreadCountsResponseInternalDTO dto,
             ICache cache)
         {
             TotalUnreadCount = GetOrDefault(dto.TotalUnreadCount, TotalUnreadCount);

--- a/Assets/Plugins/StreamChat/Core/StatefulModels/StreamMessage.cs
+++ b/Assets/Plugins/StreamChat/Core/StatefulModels/StreamMessage.cs
@@ -15,7 +15,7 @@ using StreamChat.Core.Requests;
 namespace StreamChat.Core.StatefulModels
 {
     internal sealed class StreamMessage : StreamStatefulModelBase<StreamMessage>,
-        IStreamMessage, IUpdateableFrom<MessageInternalDTO, StreamMessage>, IUpdateableFrom<MessageResponseInternalDTO, StreamMessage>
+        IStreamMessage, IUpdateableFrom<MessageInternalDTO, StreamMessage>, IUpdateableFrom2<MessageResponseInternalDTO, StreamMessage>
     {
         public event StreamMessageReactionHandler ReactionAdded;
         public event StreamMessageReactionHandler ReactionRemoved;
@@ -236,7 +236,7 @@ namespace StreamChat.Core.StatefulModels
             LoadAdditionalProperties(dto.AdditionalProperties);
         }
         
-        void IUpdateableFrom<MessageResponseInternalDTO, StreamMessage>.UpdateFromDto(MessageResponseInternalDTO dto, ICache cache)
+        void IUpdateableFrom2<MessageResponseInternalDTO, StreamMessage>.UpdateFromDto(MessageResponseInternalDTO dto, ICache cache)
         {
             _attachments.TryReplaceRegularObjectsFromDto(dto.Attachments, cache);
             //BeforeMessageSendFailed = GetOrDefault(dto.BeforeMessageSendFailed, BeforeMessageSendFailed);
@@ -248,10 +248,10 @@ namespace StreamChat.Core.StatefulModels
             _iI18n.TryReplaceValuesFromDto(dto.I18n);
             Id = GetOrDefault(dto.Id, Id);
             //_imageLabels.TryReplaceValuesFromDto(dto.ImageLabels); //StreamTodo: NOT IMPLEMENTED
-            _latestReactions.TryReplaceRegularObjectsFromDto(dto.LatestReactions, cache);
-            _mentionedUsers.TryReplaceTrackedObjects(dto.MentionedUsers, cache.Users);
+            _latestReactions.TryReplaceRegularObjectsFromDto2(dto.LatestReactions, cache);
+            _mentionedUsers.TryReplaceTrackedObjects2(dto.MentionedUsers, cache.Users);
             //dto.Mml ignored because its only server-side
-            _ownReactions.TryReplaceRegularObjectsFromDto(dto.OwnReactions, cache);
+            _ownReactions.TryReplaceRegularObjectsFromDto2(dto.OwnReactions, cache);
             ParentId = GetOrDefault(dto.ParentId, ParentId);
             PinExpires = GetOrDefault(dto.PinExpires, PinExpires);
             Pinned = GetOrDefault(dto.Pinned, Pinned);
@@ -267,8 +267,8 @@ namespace StreamChat.Core.StatefulModels
             ShowInChannel = GetOrDefault(dto.ShowInChannel, ShowInChannel);
             Silent = GetOrDefault(dto.Silent, Silent);
             Text = GetOrDefault(dto.Text, Text);
-            _mentionedUsers.TryReplaceTrackedObjects(dto.MentionedUsers, cache.Users);
-            _threadParticipants.TryReplaceTrackedObjects(dto.ThreadParticipants, cache.Users);
+            _mentionedUsers.TryReplaceTrackedObjects2(dto.MentionedUsers, cache.Users);
+            _threadParticipants.TryReplaceTrackedObjects2(dto.ThreadParticipants, cache.Users);
             Type = Type.TryLoadFromDto(dto.Type);
             UpdatedAt = GetOrDefault(dto.UpdatedAt, UpdatedAt);
             User = cache.TryCreateOrUpdate(dto.User);

--- a/Assets/Plugins/StreamChat/Core/StatefulModels/StreamUser.cs
+++ b/Assets/Plugins/StreamChat/Core/StatefulModels/StreamUser.cs
@@ -17,7 +17,7 @@ namespace StreamChat.Core.StatefulModels
     /// <inheritdoc cref="IStreamUser"/>
     internal sealed class StreamUser : StreamStatefulModelBase<StreamUser>,
         IUpdateableFrom<UserObjectInternalDTO, StreamUser>,
-        IUpdateableFrom<UserResponseInternalDTO, StreamUser>, IUpdateableFrom<OwnUserInternalDTO, StreamUser>, IUpdateableFrom<FullUserResponseInternalDTO, StreamUser>, IUpdateableFrom<UserEventPayloadInternalDTO, StreamUser>,
+        IUpdateableFrom2<UserResponseInternalDTO, StreamUser>, IUpdateableFrom3<OwnUserInternalDTO, StreamUser>, IUpdateableFrom4<FullUserResponseInternalDTO, StreamUser>, IUpdateableFrom5<UserEventPayloadInternalDTO, StreamUser>,
         IStreamUser
     {
         public event StreamUserPresenceHandler PresenceChanged;
@@ -166,7 +166,7 @@ namespace StreamChat.Core.StatefulModels
             LoadAdditionalProperties(dto.AdditionalProperties);
         }
 
-        void IUpdateableFrom<UserResponseInternalDTO, StreamUser>.UpdateFromDto(UserResponseInternalDTO dto,
+        void IUpdateableFrom2<UserResponseInternalDTO, StreamUser>.UpdateFromDto(UserResponseInternalDTO dto,
             ICache cache)
         {
             BanExpires = GetOrDefault(dto.BanExpires, BanExpires);
@@ -193,7 +193,7 @@ namespace StreamChat.Core.StatefulModels
             LoadAdditionalProperties(dto.AdditionalProperties);
         }
 
-        void IUpdateableFrom<OwnUserInternalDTO, StreamUser>.UpdateFromDto(OwnUserInternalDTO dto, ICache cache)
+        void IUpdateableFrom3<OwnUserInternalDTO, StreamUser>.UpdateFromDto(OwnUserInternalDTO dto, ICache cache)
         {
             #region OwnUser
 
@@ -231,7 +231,7 @@ namespace StreamChat.Core.StatefulModels
             LoadAdditionalProperties(dto.AdditionalProperties);
         }
         
-        void IUpdateableFrom<FullUserResponseInternalDTO, StreamUser>.UpdateFromDto(FullUserResponseInternalDTO dto,
+        void IUpdateableFrom4<FullUserResponseInternalDTO, StreamUser>.UpdateFromDto(FullUserResponseInternalDTO dto,
             ICache cache)
         {
             BanExpires = GetOrDefault(dto.BanExpires, BanExpires);
@@ -258,7 +258,7 @@ namespace StreamChat.Core.StatefulModels
             LoadAdditionalProperties(dto.AdditionalProperties);
         }
         
-        void IUpdateableFrom<UserEventPayloadInternalDTO, StreamUser>.UpdateFromDto(UserEventPayloadInternalDTO dto,
+        void IUpdateableFrom5<UserEventPayloadInternalDTO, StreamUser>.UpdateFromDto(UserEventPayloadInternalDTO dto,
             ICache cache)
         {
             BanExpires = GetOrDefault(dto.BanExpires, BanExpires);

--- a/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
+++ b/Assets/Plugins/StreamChat/Core/StreamChatClient.cs
@@ -226,7 +226,7 @@ namespace StreamChat.Core
             var dto = await InternalLowLevelClient.InternalChannelApi.GetUnreadCountsAsync();
             var response = dto.ToDomain<WrappedUnreadCountsResponseInternalDTO, StreamCurrentUnreadCounts>();
 
-            _localUserData.TryUpdateFromDto<WrappedUnreadCountsResponseInternalDTO, StreamLocalUserData>(dto, _cache);
+            ((IUpdateableFrom2<WrappedUnreadCountsResponseInternalDTO, StreamLocalUserData>)_localUserData).TryUpdateFromDto(dto, _cache);
 
             return response;
         }


### PR DESCRIPTION
…ations of the same generic interface

IL2CPP's vtable builder in Unity 6000.0.x crashes with a KeyNotFoundException in VTableBuilderComponent.OverrideInterfaceMethods when a type implements multiple closed versions of the same generic interface (e.g. ISavableTo<A> and ISavableTo<B>). The vtable builder uses an unresolved generic parameter name as a dictionary key instead of the resolved concrete type, causing a key mismatch during vtable construction. The bug is fixed in Unity 6000.2.x but affects customers on 6000.0.x.

This pattern existed across four internal generic interfaces in the SDK: ISavableTo (9 types), ILoadableFrom (9 types), IUpdateableFrom (4 types), and IStateLoadableFrom (5 types) — 27 types total.

Fix: for each interface, introduce numbered variants (e.g. ISavableTo2, ILoadableFrom2/3/4, IUpdateableFrom2/3/4/5, IStateLoadableFrom2) that are structurally identical but distinct in the type system. Each type's secondary and tertiary implementations are moved to the numbered variant, so no type ever implements multiple closed versions of the same generic interface. Matching extension method overloads ensure all existing functionality and DTO conversions are preserved.