### PR TITLE
Fix "JsonException: No parameterless constructor defined '

### DIFF
--- a/Assets/Plugins/StreamChat/link.xml
+++ b/Assets/Plugins/StreamChat/link.xml
@@ -4,6 +4,11 @@
         <namespace fullname="StreamChat.Core.InternalDTO.Models" preserve="all"/>
         <namespace fullname="StreamChat.Core.InternalDTO.Requests" preserve="all"/>
         <namespace fullname="StreamChat.Core.InternalDTO.Responses" preserve="all"/>
+        <namespace fullname="StreamChat.Core.Serialization" preserve="all"/>
+        <namespace fullname="StreamChat.Core.LowLevelClient.Models" preserve="all"/>
+        <namespace fullname="StreamChat.Core.LowLevelClient.Events" preserve="all"/>
+        <namespace fullname="StreamChat.Core.LowLevelClient.Requests" preserve="all"/>
+        <namespace fullname="StreamChat.Core.LowLevelClient.Requests.DTO" preserve="all"/>
     </assembly>
     <assembly fullname="Newtonsoft.Json">
         <namespace fullname="Newtonsoft.Json.Serialization" preserve="all"/>


### PR DESCRIPTION
Fix "JsonException: No parameterless constructor defined 'EnumeratedStructConverter`1[PushProviderTypeInternalDTO]'" error caused by Il2CPP code stripping