### PR TITLE
Add a public StreamApiException constructor

### DIFF
--- a/Assets/Plugins/StreamChat/Changelog.txt
+++ b/Assets/Plugins/StreamChat/Changelog.txt
@@ -1,6 +1,7 @@
 Unreleased:
 Features:
 
+* Add a public StreamApiException constructor (statusCode, code, errorMessage, moreInfo, duration, exceptionFields). StreamApiException is a public, catch-and-branch type (via the StreamApiExceptionExtensions.Is* helpers), but until now it could only be constructed inside the SDK from the internal APIErrorInternalDTO, so integrators could not build one to unit-test their own error handling (e.g. simulating a 403 / code 70 "no access to channels" response). The new constructor maps directly to the type's public properties and keeps APIErrorInternalDTO internal.
 * Add IStreamClientConfig.OptimisticMessageInsert (default true). When true (the existing behavior), a message you send is inserted into the local channel state and raised via IStreamChannel.MessageReceived immediately, before the server's message.new echo arrives. Set it to false to skip the optimistic local insert and wait for the server echo instead, so every participant - including the sender - observes messages in the same server-defined order. Useful when consistent cross-client ordering matters more than instant local feedback (e.g. a shared, broadcast-ordered feed).
 
 v5.5.0:

--- a/Assets/Plugins/StreamChat/Core/Exceptions/StreamApiException.cs
+++ b/Assets/Plugins/StreamChat/Core/Exceptions/StreamApiException.cs
@@ -79,18 +79,46 @@ namespace StreamChat.Core.Exceptions
         public IReadOnlyDictionary<string, string> ExceptionFields => _exceptionFields;
 
         internal StreamApiException(APIErrorInternalDTO apiError)
-            : base(
-                $"{apiError.Message}, Error Code: {apiError.Code}, Http Status Code: {apiError.StatusCode}, More info: {apiError.MoreInfo}, Exception fields: {PrintExceptionFields(apiError)}")
+            : this(apiError.StatusCode, apiError.Code, apiError.Message, apiError.MoreInfo, apiError.Duration,
+                apiError.ExceptionFields)
         {
-            StatusCode = apiError.StatusCode;
-            Code = apiError.Code;
-            Duration = apiError.Duration;
-            ErrorMessage = apiError.Message;
-            MoreInfo = apiError.MoreInfo;
+        }
 
-            if (apiError.ExceptionFields != null && apiError.ExceptionFields.Count > 0)
+        /// <summary>
+        /// Construct an exception representing a specific API error. Intended for integrators who need to
+        /// exercise their own <see cref="StreamApiException"/> handling in unit tests (e.g. simulating a
+        /// 403 / code 70 "no access to channels" response) without depending on the internal
+        /// <see cref="APIErrorInternalDTO"/> type. Every argument maps directly to a public property of this type.
+        /// </summary>
+        public StreamApiException(
+            int statusCode,
+            int code,
+            string errorMessage = null,
+            string moreInfo = null,
+            string duration = null,
+            IReadOnlyDictionary<string, string> exceptionFields = null)
+            : this((int?)statusCode, code, errorMessage, moreInfo, duration, exceptionFields)
+        {
+        }
+
+        private StreamApiException(
+            int? statusCode,
+            int? code,
+            string errorMessage,
+            string moreInfo,
+            string duration,
+            IReadOnlyDictionary<string, string> exceptionFields)
+            : base(BuildMessage(errorMessage, code, statusCode, moreInfo, exceptionFields))
+        {
+            StatusCode = statusCode;
+            Code = code;
+            Duration = duration;
+            ErrorMessage = errorMessage;
+            MoreInfo = moreInfo;
+
+            if (exceptionFields != null && exceptionFields.Count > 0)
             {
-                _exceptionFields = new Dictionary<string, string>(apiError.ExceptionFields);
+                _exceptionFields = new Dictionary<string, string>(exceptionFields);
             }
         }
 
@@ -98,18 +126,23 @@ namespace StreamChat.Core.Exceptions
 
         private readonly Dictionary<string, string> _exceptionFields;
 
-        private static string PrintExceptionFields(APIErrorInternalDTO apiError)
+        // Shared by both constructors so the message format stays identical however the exception is built.
+        private static string BuildMessage(string message, int? code, int? statusCode, string moreInfo,
+            IReadOnlyDictionary<string, string> exceptionFields)
+            => $"{message}, Error Code: {code}, Http Status Code: {statusCode}, More info: {moreInfo}, Exception fields: {PrintExceptionFields(exceptionFields)}";
+
+        private static string PrintExceptionFields(IReadOnlyDictionary<string, string> exceptionFields)
         {
-            if (apiError.ExceptionFields == null)
+            if (exceptionFields == null)
             {
                 return "None";
             }
 
             _sb.Length = 0;
 
-            var count = apiError.ExceptionFields.Count;
+            var count = exceptionFields.Count;
             var index = 0;
-            foreach (var keyValuePair in apiError.ExceptionFields)
+            foreach (var keyValuePair in exceptionFields)
             {
                 _sb.Append(keyValuePair.Key);
                 _sb.Append(": ");


### PR DESCRIPTION
## Summary

`StreamApiException` is a **public, catch-and-branch type** — integrators are expected to `catch` it, inspect `StatusCode`/`Code`, and branch via the public `StreamApiExceptionExtensions.Is*` helpers (`IsNoAccessToChannelsError`, `IsRateLimitExceededError`, etc.). But its only constructor is `internal` and takes the `internal` `APIErrorInternalDTO`, so **integrators can't construct one to unit-test their own error handling**.

This means there's no supported way to write a test like "when a channel-hydration call throws a 403 / code 70, my code drops the channel from the local list instead of rethrowing" — you can't produce the exception to feed your handler without reaching into SDK internals (e.g. an `InternalsVisibleTo` patch against a vendored copy).

This PR adds a public constructor over the type's already-public fields. `APIErrorInternalDTO` stays internal.

## Change

```csharp
public StreamApiException(
    int statusCode,
    int code,
    string errorMessage = null,
    string moreInfo = null,
    string duration = null,
    IReadOnlyDictionary<string, string> exceptionFields = null)
```

Both this and the existing DTO constructor funnel through a single private constructor and a shared `BuildMessage` helper, so the `Exception.Message` format is **identical regardless of how the exception is built** (keeps log/crash-report grouping consistent). Every parameter maps 1:1 to an existing public property; nothing internal is exposed.

## Why this shape

- A plain public constructor (vs. a `ForTesting`-style factory) is idiomatic for an `Exception` subclass and reads naturally at call sites. Hand-constructing a representative API error is legitimately useful beyond tests (fakes, mocks, replay tooling).
- This matches the signature suggested in the support thread; `APIErrorInternalDTO` is kept internal as requested.

## Integrator impact (before → after)

Before — only possible by granting `InternalsVisibleTo` to the SDK and using the internal DTO:

```csharp
// Requires internal access to both StreamApiException's ctor and APIErrorInternalDTO
private static StreamApiException NoAccessToChannelsException()
    => new(new APIErrorInternalDTO
    {
        StatusCode = StreamApiException.NoAccessToChannelsErrorHttpStatusCode, // 403
        Code       = StreamApiException.NoAccessToChannelsErrorStreamCode,     // 70
        Message    = "channels match your query but cannot be returned",
    });
```

After — public API only:

```csharp
private static StreamApiException NoAccessToChannelsException()
    => new(
        StreamApiException.NoAccessToChannelsErrorHttpStatusCode, // 403
        StreamApiException.NoAccessToChannelsErrorStreamCode,     // 70
        "channels match your query but cannot be returned");
```

## Testing

- Verified the refactor produces byte-identical `Exception.Message` output to the previous inline code across all error shapes (null message/moreInfo, null/empty/multi-entry `exceptionFields`).
- Existing CI runtime test suite covers the rest.

## Changelog

Added an entry under `Unreleased / Features`.
