### PR TITLE
Log transient connect/transport failures as warnings in LogIfFailed

### DIFF
--- a/Assets/Plugins/StreamChat/Changelog.txt
+++ b/Assets/Plugins/StreamChat/Changelog.txt
@@ -3,6 +3,10 @@ Features:
 
 * Add IStreamClientConfig.OptimisticMessageInsert (default true). When true (the existing behavior), a message you send is inserted into the local channel state and raised via IStreamChannel.MessageReceived immediately, before the server's message.new echo arrives. Set it to false to skip the optimistic local insert and wait for the server echo instead, so every participant - including the sender - observes messages in the same server-defined order. Useful when consistent cross-client ordering matters more than instant local feedback (e.g. a shared, broadcast-ordered feed).
 
+Fixes:
+
+* TaskUtils.LogIfFailed now logs connectivity/transport failures as warnings instead of errors/exceptions. The SDK fire-and-forgets its connect, reconnect, and state-restore operations through LogIfFailed; when the device is offline these fail with HttpRequestException / WebException / SocketException / IOException / TimeoutException, which the reconnect flow recovers from - so surfacing them at error severity flooded crash/error reporting (Sentry, Bugsnag, etc.) with handled, non-actionable noise. Genuine (non-connectivity) failures still log as exceptions. Complements the connection-attempt-timeout fix from PR #213.
+
 v5.5.0:
 Features:
 

--- a/Assets/Plugins/StreamChat/Libs/Utils/TaskUtils.cs
+++ b/Assets/Plugins/StreamChat/Libs/Utils/TaskUtils.cs
@@ -17,7 +17,19 @@ namespace StreamChat.Libs.Utils
                         return;
                     }
 
-                    Debug.LogException(_.Exception);
+                    if (IsTransientNetworkException(_.Exception))
+                    {
+                        // A connectivity/transport failure (no network, a dropped/refused connection,
+                        // a TLS or socket read failure, or a request timeout) on a fire-and-forget task
+                        // is an expected, transient condition the reconnect flow recovers from. Log it as
+                        // a warning instead of an exception so it does not flood crash/error reporting with
+                        // handled, non-actionable noise. Genuine failures still surface as exceptions.
+                        Debug.LogWarning(_.Exception.ToString());
+                    }
+                    else
+                    {
+                        Debug.LogException(_.Exception);
+                    }
                 },
                 TaskScheduler.FromCurrentSynchronizationContext());
 
@@ -53,11 +65,46 @@ namespace StreamChat.Libs.Utils
 
                     if (_sb.Length > 0)
                     {
-                        Debug.LogError(_sb.ToString());
+                        // See LogIfFailed(Task, ILogs): connectivity/transport failures are expected,
+                        // transient, and recovered by the reconnect flow, so log them as warnings rather
+                        // than errors to avoid flooding crash/error reporting with non-actionable noise.
+                        if (IsTransientNetworkException(_.Exception))
+                        {
+                            Debug.LogWarning(_sb.ToString());
+                        }
+                        else
+                        {
+                            Debug.LogError(_sb.ToString());
+                        }
                         _sb.Length = 0;
                     }
                 },
                 TaskScheduler.FromCurrentSynchronizationContext());
+
+        // True when a task faulted because of a connectivity / transport problem — no network, a
+        // dropped/refused connection, a TLS or socket read failure, or a request timeout — rather than
+        // a genuine application error. The SDK fire-and-forgets its connect / reconnect / restore
+        // operations through LogIfFailed; when the device is offline these fail with such exceptions
+        // and the reconnect flow recovers from them, so they are logged as warnings, not errors.
+        private static bool IsTransientNetworkException(AggregateException aggregateException)
+        {
+            foreach (Exception inner in aggregateException.Flatten().InnerExceptions)
+            {
+                for (Exception e = inner; e != null; e = e.InnerException)
+                {
+                    if (e is System.Net.Http.HttpRequestException ||
+                        e is System.Net.WebException ||
+                        e is System.Net.Sockets.SocketException ||
+                        e is System.IO.IOException ||
+                        e is TimeoutException)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
 
         private static  readonly StringBuilder _sb = new StringBuilder();
     }


### PR DESCRIPTION
## Summary

`TaskUtils.LogIfFailed` logs **every** faulted fire-and-forget task at error severity (`Debug.LogException` / `Debug.LogError`). The SDK uses it on its connect / reconnect / state-restore operations:

- `ConnectUserAsync(...).LogIfFailed()` (reconnect path, `StreamChatLowLevelClient`)
- `RestoreStateLostDuringDisconnect().LogIfFailed()` (`StreamChatClient`)
- `_websocketClient.ConnectAsync(connectionUri).LogIfFailed(_logs)` (`StreamChatLowLevelClient`)
- `DisconnectAsync().LogIfFailed(_logs)` (`NativeWebSocketWrapper`)

When the device is **offline**, these fail with connectivity/transport exceptions and get reported at error severity — flooding crash/error reporting (Sentry, Bugsnag, etc.) with handled, non-actionable noise. A representative production stack:

```
System.Net.Http.HttpRequestException: An error occurred while sending the request
 ---> System.Net.WebException: Error: SecureChannelFailure (Unable to read data from the transport connection: Network subsystem is down.)
 ---> System.IO.IOException: Unable to read data from the transport connection: Network subsystem is down.
 ---> System.Net.Sockets.SocketException: Network subsystem is down
   ...
  at StreamChat.Libs.Utils.<>c.<LogIfFailed>b__1_0 (Task)
```

These are expected, transient failures that the reconnect flow recovers from — they shouldn't be logged as exceptions.

## Change

`LogIfFailed` (both overloads) now classifies the fault: connectivity/transport exceptions are logged via `Debug.LogWarning`, everything else stays `Debug.LogException` / `Debug.LogError`. A shared helper walks the `AggregateException` (flattened, plus each inner chain) for:

- `System.Net.Http.HttpRequestException`
- `System.Net.WebException`
- `System.Net.Sockets.SocketException`
- `System.IO.IOException`
- `TimeoutException`

Genuine (non-connectivity) failures are unaffected and still surface as exceptions.

## Why this shape

This is the same rationale as **#213** ("Log WebSocket connection-attempt timeout as a warning, not an exception"), applied at the `LogIfFailed` logger. #213 covered the WS `TimeoutException` inside `HandleConnectionFailedAsync`; this covers the REST connect/restore failures that fire-and-forget through `LogIfFailed` and never reach that handler.

## Notes

- C# 8-compatible syntax (no `or`/`is not` patterns), fully-qualified type names so no new `using`s are added.
- Changelog updated under `Unreleased / Fixes`.
