### PR TITLE
Fix Gradle-path API guard: use UNITY_6000_2_OR_NEWER (Gradle.path was added in 6000.2, not 6000.0)

### DIFF
--- a/Assets/Plugins/StreamChat/EditorTools/StreamEditorTools.cs
+++ b/Assets/Plugins/StreamChat/EditorTools/StreamEditorTools.cs
@@ -55,7 +55,7 @@ namespace StreamChat.EditorTools
                 $"{nameof(AndroidExternalToolsSettings.jdkRootPath)}: {AndroidExternalToolsSettings.jdkRootPath}");
             sb.AppendLine(
                 $"{nameof(AndroidExternalToolsSettings.ndkRootPath)}: {AndroidExternalToolsSettings.ndkRootPath}");
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_6000_2_OR_NEWER
             sb.AppendLine(
                 $"GradlePath: {AndroidExternalToolsSettings.Gradle.path}");
 #else
@@ -104,7 +104,7 @@ namespace StreamChat.EditorTools
 
                 if (!string.IsNullOrEmpty(androidExternalToolsSettings.GradlePath))
                 {
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_6000_2_OR_NEWER
                     sb.AppendLine(
                         $"Setting GradlePath to: {androidExternalToolsSettings.GradlePath}");
                     AndroidExternalToolsSettings.Gradle.path = androidExternalToolsSettings.GradlePath;


### PR DESCRIPTION
## Problem

`StreamEditorTools` guards its Android Gradle-path access with `#if UNITY_6000_0_OR_NEWER` and calls `AndroidExternalToolsSettings.Gradle.path`. However, the nested `Gradle` grouping (`Gradle.path` / `Gradle.userHomePath`) was only introduced in **Unity 6000.2**. On **6000.0.x** and **6000.1.x**, `AndroidExternalToolsSettings` exposes only the flat `gradlePath` string property, so the editor tools fail to compile there:

```
StreamEditorTools.cs(60,61): error CS0117: 'AndroidExternalToolsSettings' does not contain a definition for 'Gradle'
```

This breaks the package on any 6000.0 / 6000.1 LTS project (e.g. Unity 6000.0.71f1).

## Fix

Change the guard boundary in both `#if` blocks from `UNITY_6000_0_OR_NEWER` to `UNITY_6000_2_OR_NEWER`:

- **6000.0 / 6000.1** → flat `AndroidExternalToolsSettings.gradlePath` (not deprecated on these versions)
- **6000.2+** → nested `AndroidExternalToolsSettings.Gradle.path` (on 6000.2 `gradlePath` is `[Obsolete]`, so this also avoids the deprecation warning)

## References

- [`gradlePath`](https://docs.unity3d.com/ScriptReference/Android.AndroidExternalToolsSettings-gradlePath.html) — current / 6000.0–6000.1 API
- [`Gradle.path`](https://docs.unity3d.com/6000.2/Documentation/ScriptReference/Android.AndroidExternalToolsSettings.Gradle-path.html) — 6000.2 API (and the [6000.2 `gradlePath` page](https://docs.unity3d.com/6000.2/Documentation/ScriptReference/Android.AndroidExternalToolsSettings-gradlePath.html) marks it obsolete: "Use Gradle.path instead")