### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/main.ci.cd.workflow.yml
+++ b/.github/workflows/main.ci.cd.workflow.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: "0 0 * * *"  # run daily at midnight (UTC)
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+
 jobs:
   runtime-tests:
     name: Runtime Tests (IL2CPP)


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **2** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge
