### PR TITLE
Fix inverted staleness guard on the /sync reconnect catch-up

### DIFF
--- a/Assets/Plugins/StreamChat/Changelog.txt
+++ b/Assets/Plugins/StreamChat/Changelog.txt
@@ -19,6 +19,7 @@ Features:
 
 Fixes:
 
+* Fix the 30-day staleness guard on the reconnect /sync catch-up computing its age backwards (lastEventReceivedAt - now, which is negative for any past timestamp), so the guard never fired and /sync was called even with a LastSyncAt the server rejects. Also removes a dead local that was almost certainly the intended operand.
 * TaskUtils.LogIfFailed now logs connectivity/transport failures as warnings instead of errors/exceptions. The SDK fire-and-forgets its connect, reconnect, and state-restore operations through LogIfFailed; when the device is offline these fail with HttpRequestException / WebException / SocketException / IOException / TimeoutException, which the reconnect flow recovers from - so surfacing them at error severity flooded crash/error reporting (Sentry, Bugsnag, etc.) with handled, non-actionable noise. Genuine (non-connectivity) failures still log as exceptions. Complements the connection-attempt-timeout fix from PR #213.
 
 v5.5.0:

--- a/Assets/Plugins/StreamChat/Core/LowLevelClient/StreamChatLowLevelClient.cs
+++ b/Assets/Plugins/StreamChat/Core/LowLevelClient/StreamChatLowLevelClient.cs
@@ -445,10 +445,10 @@ namespace StreamChat.Core.LowLevelClient
 
             var lastEventReceivedAt = _disconnectionLastEventReceivedAt.Value;
 
-            var currentServerTime = DateTimeOffset.UtcNow.ToOffset(lastEventReceivedAt.Offset);
-
-            // Check if less than 30 days
-            var diff = lastEventReceivedAt - _timeService.Now;
+            // Check if less than 30 days. Past that the server rejects LastSyncAt, so this only
+            // skips a request that was certain to fail — it is not a recovery path. The SDK has no
+            // re-hydrate fallback of its own, so bridging a gap this large is the consumer's job.
+            TimeSpan diff = _timeService.Now - lastEventReceivedAt;
             if (diff.TotalDays > 30)
             {
                 return;


### PR DESCRIPTION
`FetchAndProcessEventsSinceLastReceivedEvent` has a guard meant to skip `/sync` when the last received event is older than 30 days, past which the server rejects `LastSyncAt`. It computes the age backwards:

```csharp
var diff = lastEventReceivedAt - _timeService.Now;   // past - now => NEGATIVE
if (diff.TotalDays > 30) { return; }                 // therefore never true
```

`lastEventReceivedAt` is always in the past, so the branch is unreachable and `/sync` is issued regardless of age. The request then fails server-side, and because the only caller (`StreamChatClient.RestoreStateLostDuringDisconnect`) invokes it fire-and-forget through `LogIfFailed`, the exception reaches the logger and nothing else — the client silently gets no replay at all.

Corrected to `_timeService.Now - lastEventReceivedAt`. `DateTimeOffset` subtraction compares `UtcDateTime`, so a local-offset vs server-offset mismatch is handled correctly.

Also removes the dead `currentServerTime` local directly above it. It was never read, and was almost certainly the intended left operand — the tell that this comparison was written wrong and never exercised.

### Scope

This only skips a request that was certain to fail; it is not a recovery path. The SDK has no re-hydrate fallback of its own, so bridging a gap that large remains the consumer's job. Reaching the 30-day bound also requires 30+ days of uptime on one client, so the practical impact is small — we are sending it because the guard reads as active protection when it is dead code, which is a trap for the next reader of this method.

A related but separately reachable failure in the same method (the server refusing `/sync` on event *count* rather than age, which happens within hours on a busy channel) is in a follow-up PR that stacks on this one.

### Testing

No test added: `FetchAndProcessEventsSinceLastReceivedEvent` is reached only through the reconnect path and there is no seam in the existing test setup to drive it. Happy to add coverage if you can point at the right approach.
