### PR TITLE
Add Translation and Slow Mode docs code samples

### DIFF
--- a/Assets/Plugins/StreamChat/Samples/SlowModeCodeSamples.cs
+++ b/Assets/Plugins/StreamChat/Samples/SlowModeCodeSamples.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using StreamChat.Core;
+using StreamChat.Core.StatefulModels;
+using UnityEngine;
+
+namespace StreamChat.Samples
+{
+    /// <summary>
+    /// Code examples for the features/advanced/slow-mode/ docs page
+    /// </summary>
+    internal sealed class SlowModeCodeSamples
+    {
+        public async Task EnableDisableSlowMode()
+        {
+            var channel = await Client.GetOrCreateChannelWithIdAsync(ChannelType.Messaging, "channel-id");
+
+// The Unity SDK has no dedicated slow mode method - set the channel's
+// `cooldown` field, in seconds, with a partial channel update
+
+// Enable slow mode with a 1s cooldown
+            await channel.UpdatePartialAsync(new Dictionary<string, object>
+            {
+                { "cooldown", 1 }
+            });
+
+// Increase cooldown to 30s
+            await channel.UpdatePartialAsync(new Dictionary<string, object>
+            {
+                { "cooldown", 30 }
+            });
+
+// Disable slow mode by setting the cooldown back to 0
+            await channel.UpdatePartialAsync(new Dictionary<string, object>
+            {
+                { "cooldown", 0 }
+            });
+
+// Read the current cooldown. Null or 0 means slow mode is off
+            Debug.Log(channel.Cooldown);
+        }
+
+        public async Task GateSendingUiOnRemainingCooldown()
+        {
+            var channel = await Client.GetOrCreateChannelWithIdAsync(ChannelType.Messaging, "channel-id");
+
+// Disable/enable the send button based on the remaining cooldown
+            var remaining = GetRemainingCooldown(channel);
+            if (remaining > 0)
+            {
+                // disable/enable UI is app-specific
+                DisableMessageSendingUi(remaining);
+            }
+        }
+
+// The Unity SDK exposes the configured cooldown via `channel.Cooldown`, but does
+// not track the remaining time for you. Compute it from the local user's last
+// message in the channel
+
+        private int GetRemainingCooldown(IStreamChannel channel)
+        {
+            var cooldown = channel.Cooldown ?? 0;
+            if (cooldown <= 0)
+            {
+                return 0;
+            }
+
+            var localUserId = Client.LocalUserData.UserId;
+
+            var lastOwnMessage = channel.Messages
+                .Where(m => m.User != null && m.User.Id == localUserId)
+                .OrderByDescending(m => m.CreatedAt)
+                .FirstOrDefault();
+
+            if (lastOwnMessage == null)
+            {
+                return 0;
+            }
+
+            var elapsed = (DateTimeOffset.UtcNow - lastOwnMessage.CreatedAt).TotalSeconds;
+            var remaining = cooldown - (int)elapsed;
+
+            return remaining > 0 ? remaining : 0;
+        }
+
+        private void DisableMessageSendingUi(int forSeconds)
+        {
+        }
+
+        private IStreamChatClient Client { get; } = StreamChatClient.CreateDefaultClient();
+    }
+}

--- a/Assets/Plugins/StreamChat/Samples/SlowModeCodeSamples.cs
+++ b/Assets/Plugins/StreamChat/Samples/SlowModeCodeSamples.cs
@@ -8,11 +8,11 @@ using UnityEngine;
 
 namespace StreamChat.Samples
 {
-    /// <summary>
-    /// Code examples for the features/advanced/slow-mode/ docs page
-    /// </summary>
     internal sealed class SlowModeCodeSamples
     {
+        /// <summary>
+        /// https://getstream.io/chat/docs/unity/slow-mode/?language=unity#channel-slow-mode
+        /// </summary>
         public async Task EnableDisableSlowMode()
         {
             var channel = await Client.GetOrCreateChannelWithIdAsync(ChannelType.Messaging, "channel-id");
@@ -42,6 +42,9 @@ namespace StreamChat.Samples
             Debug.Log(channel.Cooldown);
         }
 
+        /// <summary>
+        /// https://getstream.io/chat/docs/unity/slow-mode/?language=unity#channel-slow-mode
+        /// </summary>
         public async Task GateSendingUiOnRemainingCooldown()
         {
             var channel = await Client.GetOrCreateChannelWithIdAsync(ChannelType.Messaging, "channel-id");

--- a/Assets/Plugins/StreamChat/Samples/SlowModeCodeSamples.cs.meta
+++ b/Assets/Plugins/StreamChat/Samples/SlowModeCodeSamples.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e7409c84722c44348688345448c3aea4
+timeCreated: 1754913600

--- a/Assets/Plugins/StreamChat/Samples/TranslationCodeSamples.cs
+++ b/Assets/Plugins/StreamChat/Samples/TranslationCodeSamples.cs
@@ -7,11 +7,11 @@ using UnityEngine;
 
 namespace StreamChat.Samples
 {
-    /// <summary>
-    /// Code examples for the features/translation/ docs page
-    /// </summary>
     internal sealed class TranslationCodeSamples
     {
+        /// <summary>
+        /// https://getstream.io/chat/docs/unity/translation/?language=unity#i18n-data
+        /// </summary>
         public void ReadMessageTranslations()
         {
             IStreamMessage message = null;
@@ -32,6 +32,9 @@ namespace StreamChat.Samples
             var text = message.I18n.TryGetValue("fr_text", out var french) ? french : message.Text;
         }
 
+        /// <summary>
+        /// https://getstream.io/chat/docs/unity/translation/?language=unity#enabling-automatic-translation
+        /// </summary>
         public async Task EnableChannelAutoTranslation()
         {
             var channel = await Client.GetOrCreateChannelWithIdAsync(ChannelType.Messaging, "channel-id");
@@ -51,6 +54,9 @@ namespace StreamChat.Samples
 // Use one of our server-side SDKs or the Stream Dashboard for that.
         }
 
+        /// <summary>
+        /// https://getstream.io/chat/docs/unity/translation/?language=unity#set-user-language
+        /// </summary>
         public async Task SetUserLanguage()
         {
 // Set the language used to translate messages for a user

--- a/Assets/Plugins/StreamChat/Samples/TranslationCodeSamples.cs
+++ b/Assets/Plugins/StreamChat/Samples/TranslationCodeSamples.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using StreamChat.Core;
+using StreamChat.Core.Requests;
+using StreamChat.Core.StatefulModels;
+using UnityEngine;
+
+namespace StreamChat.Samples
+{
+    /// <summary>
+    /// Code examples for the features/translation/ docs page
+    /// </summary>
+    internal sealed class TranslationCodeSamples
+    {
+        public void ReadMessageTranslations()
+        {
+            IStreamMessage message = null;
+
+// Translations are exposed on the message as the I18n dictionary
+            foreach (var pair in message.I18n)
+            {
+                Debug.Log($"{pair.Key} = {pair.Value}"); // e.g. "fr_text = Bonjour, ..."
+            }
+
+// The original language is under the "language" key
+            if (message.I18n.TryGetValue("language", out var originalLanguage))
+            {
+                Debug.Log(originalLanguage); // "en"
+            }
+
+// Read a specific translation, falling back to the original text
+            var text = message.I18n.TryGetValue("fr_text", out var french) ? french : message.Text;
+        }
+
+        public async Task EnableChannelAutoTranslation()
+        {
+            var channel = await Client.GetOrCreateChannelWithIdAsync(ChannelType.Messaging, "channel-id");
+
+// Enable auto-translation for a single channel
+            await channel.UpdatePartialAsync(new Dictionary<string, object>
+            {
+                { "auto_translation_enabled", true },
+                { "auto_translation_language", "en" }
+            });
+
+// Read the current settings back from the channel
+            Debug.Log(channel.AutoTranslationEnabled);
+            Debug.Log(channel.AutoTranslationLanguage);
+
+// Enabling auto-translation for the whole app is a server-side operation.
+// Use one of our server-side SDKs or the Stream Dashboard for that.
+        }
+
+        public async Task SetUserLanguage()
+        {
+// Set the language used to translate messages for a user
+            await Client.UpsertUsersAsync(new[]
+            {
+                new StreamUserUpsertRequest
+                {
+                    Id = "user-id",
+                    Language = "fr"
+                }
+            });
+        }
+
+        private IStreamChatClient Client { get; } = StreamChatClient.CreateDefaultClient();
+    }
+}

--- a/Assets/Plugins/StreamChat/Samples/TranslationCodeSamples.cs.meta
+++ b/Assets/Plugins/StreamChat/Samples/TranslationCodeSamples.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: aba271a3dfd6486e9e5638f64c45af94
+timeCreated: 1754913600


### PR DESCRIPTION
Requested in GetStream/docs-content#1497 — keeping docs snippets compiled here so the SDK and docs stay in sync.

Two new files alongside the existing `*CodeSamples.cs`:

| File | Backs |
| ---- | ----- |
| `TranslationCodeSamples.cs` | [Translation](https://getstream.io/chat/docs/unity/translation/) |
| `SlowModeCodeSamples.cs` | [Slow Mode & Throttling](https://getstream.io/chat/docs/unity/slow-mode/) |

## Why these two

Both docs pages carried a `// This feature is not yet available in the Unity SDK` placeholder for every Unity tab, but the client-side APIs already ship:

- **Translation** — `IStreamMessage.I18n` exposes the translation dictionary, `IStreamChannel.AutoTranslationEnabled` / `AutoTranslationLanguage` expose the channel settings, and `StreamUserUpsertRequest.Language` sets a user's language. Only the translate endpoint and app-level auto-translation are genuinely server-side, and the sample says so in a comment.
- **Slow Mode** — there's no dedicated method, but `channel.UpdatePartialAsync` sets the `cooldown` field and `IStreamChannel.Cooldown` reads it back. The second sample computes the remaining cooldown from `Cooldown` plus the local user's last message, since the SDK doesn't track that for you — this is the part a Unity app needs in order to gate its send button.

## Notes for review

- Both follow the conventions in this folder: `internal sealed class`, `private IStreamChatClient Client { get; } = StreamChatClient.CreateDefaultClient();`, and doc-extracted regions dedented to column 0.
- `SlowModeCodeSamples.GetRemainingCooldown` is the one piece of real logic rather than an API call. It's deliberately framed as "here's how you'd compute this" — if you'd prefer a `GetRemainingCooldown()` helper on `IStreamChannel` instead, that would make both the sample and the docs page a couple of lines long, and I'd happily follow up.
- I haven't been able to open this in the Editor, so the samples are unverified against an actual compile — every symbol and signature was checked against `develop`, but a build on your side would be worth having before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
